### PR TITLE
Fixes STAR bug, adds alignment check and the parameter sampleLevel

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ nextflow run SciLifeLab/NGI-RNAseq --reads '*_R{1,2}.fastq.gz' --genome 'GRCm38'
 or using a more manual approach ( require you to clone the git repository)
 
 ```
-nextflow path_to_NGI-RNAseq/main.nf -c path_to_NGI-RNAseq/example_uppmax_config --reads '*_R{1,2}.fastq.gz' --genome 'GRCm38'
+nextflow path_to_NGI-RNAseq/main.nf -c path_to_your_nextflow_config --reads '*_R{1,2}.fastq.gz' --genome 'GRCm38'
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ The typical command for running the pipeline is as follows:
 ```
 nextflow run SciLifeLab/NGI-RNAseq --reads '*_R{1,2}.fastq.gz' --genome 'GRCm38'
 ```
+or using a more manual approach ( require you to clone the git repository)
+
+```
+nextflow path_to_NGI-RNAseq/main.nf -c path_to_NGI-RNAseq/example_uppmax_config --reads '*_R{1,2}.fastq.gz' --genome 'GRCm38'
+```
+
 
 ### `--reads`
 Location of the input FastQ files:
@@ -68,6 +74,11 @@ The human `GRCh37` genome is set as default.
 ```
 The `example_uppmax_config` file currently has the location of references for `GRCh37` (Human), `GRCm38` (Mouse)
 and `sacCer2` (Yeast).
+
+### `--sampleLevel`
+Used to turn of the edgeR MDS and heatmap, which require at least three samples to work. I.e use this when
+running on one or two sample only. 
+
 
 ### `-c`
 Specify the path to a specific config file (this is a core NextFlow command). Useful if using different UPPMAX

--- a/main.nf
+++ b/main.nf
@@ -321,7 +321,7 @@ process rseqc {
           .saturation.{txt,pdf}                  // RPKM_saturation
      */
      
-     if (!params.standRule){
+     if (!params.strandRule){
         if (single){
             params.strandRule ='++,--'
         } else {
@@ -341,7 +341,7 @@ process rseqc {
      infer_experiment.py -i $bam_rseqc -r $bed12 > ${bam_rseqc}.infer_experiment.txt
      read_distribution.py -i $bam_rseqc -r $bed12 > ${bam_rseqc}.read_distribution.txt
      read_duplication.py -i $bam_rseqc -o ${bam_rseqc}.read_duplication
-     RPKM_saturation.py -i $bam_rseqc -r $bed12 -d $strandRule -o ${bam_rseqc}.RPKM_saturation
+     RPKM_saturation.py -i $bam_rseqc -r $bed12 -d ${params.strandRule} -o ${bam_rseqc}.RPKM_saturation
      """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -17,6 +17,7 @@
  --index [path to STAR index]
  --gtf [path to GTF file]
  --reads [path to input files]
+ --sampleLevel [set to true to run on sample and not project level, i.e skipping MDS plot]
  
  For example:
  $ nextflow main.nf --reads 'path/to/data/sample_*_{1,2}.fq.gz'

--- a/main.nf
+++ b/main.nf
@@ -77,7 +77,7 @@ nxtflow_libs = file(params.rlocation)
 nxtflow_libs.mkdirs()
 
 single = 'null'
-params.sampleLevel = false
+params.sampleLevel = null
 params.strandRule = false
 
 log.info "===================================="
@@ -272,13 +272,14 @@ aligned.filter { logs, bams -> check_log(logs) }
     SPLIT_BAMS.into {bam_count; bam_rseqc; bam_preseq; bam_markduplicates; bam_featurecounts; bam_stringtieFPKM}
 
 //Counts the number of bam files from STAR. Uses this to determine whether to run 'sampleCorrelation' process or not
-bam_count.count()
-    .subscribe { if (count.toFloat() <= '3'.toFloat()){
-                    params.sampleLevel = true
-                    } else {
-                    params.sampleLevel = false
-                    }
-
+if (isNull(params.sampleLevel)){
+    bam_count.count()
+        .subscribe { if (count.toFloat() <= '3'.toFloat()){
+                        params.sampleLevel = true
+                        } else {
+                        params.sampleLevel = false
+                        }
+}}
 /*
  * STEP 4 - RSeQC analysis
  */
@@ -340,7 +341,7 @@ process rseqc {
      infer_experiment.py -i $bam_rseqc -r $bed12 > ${bam_rseqc}.infer_experiment.txt
      read_distribution.py -i $bam_rseqc -r $bed12 > ${bam_rseqc}.read_distribution.txt
      read_duplication.py -i $bam_rseqc -o ${bam_rseqc}.read_duplication
-     RPKM_saturation.py -i $bam_rseqc -r $bed12 -d $STRAND_RULE -o ${bam_rseqc}.RPKM_saturation
+     RPKM_saturation.py -i $bam_rseqc -r $bed12 -d $strandRule -o ${bam_rseqc}.RPKM_saturation
      """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -76,6 +76,7 @@ nxtflow_libs = file(params.rlocation)
 nxtflow_libs.mkdirs()
 
 single = 'null'
+params.sampleLevel = false
 
 log.info "===================================="
 log.info " RNAbp : RNA-Seq Best Practice v${version}"
@@ -521,6 +522,8 @@ process stringtieFPKM {
  * STEP 10 - edgeR MDS and heatmap
  */
 
+
+if (params.sampleLevel == false) {
 process sample_correlation {
      module 'bioinfo-tools'
      module 'R/3.2.3'
@@ -632,7 +635,7 @@ process sample_correlation {
      file.create("corr.done")
      """
 
-}
+}}
 
 
 /*


### PR DESCRIPTION
The Prefix was previously randomly drawn from a list thus causing samples to be incorrectly named.
Also added a check for very low alignment. If STAR exits with less than 10% unique alignment then downstream analysis for that sample will not start. This to avoid having them run and then fail.

Also added the `sampleLevel` parameter which if set to `true` skips the sample correlation process.