### PR TITLE
Made env module MultiQC load only if not already found in PATH

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -669,8 +669,6 @@ process sample_correlation {
  * STEP 11 MultiQC
  */
 process multiqc {
-    module 'bioinfo-tools'
-    module 'MultiQC'
     
     memory '4GB'
     time '4h'
@@ -694,7 +692,10 @@ process multiqc {
     file '*multiqc_report.html'
     file '*multiqc_data'
     
+    script:
     """
+    # Load MultiQC with environment module if not already in PATH
+    type multiqc >/dev/null 2>&1 || { module load multiqc; };
     multiqc -f -t ngi .
     """
 }

--- a/main.nf
+++ b/main.nf
@@ -669,6 +669,7 @@ process sample_correlation {
  * STEP 11 MultiQC
  */
 process multiqc {
+    module 'bioinfo-tools'
     
     memory '4GB'
     time '4h'


### PR DESCRIPTION
We have MultiQC installed in our conda environment with specific config options, plus the MultiQC_NGI plugin and other special stuff.

Running `module load MultiQC` at the top of the process will bring the system version of MultiQC into the PATH and take precedence over our conda version.

This change checks for `multiqc` on the PATH within the process and tries to load it with environment modules if it's not found.
