### PR TITLE
Version numbers to remaining processes

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -398,7 +398,7 @@ process markDuplicates {
         VALIDATION_STRINGENCY=LENIENT
 
     #Printing out version number to standard out
-    echo "File name: $bam_markduplicates MarkDuplicates version "\$(java -Xmx2g -jar \$PICARD_HOME/picard.jar  MarkDuplicates --version 2>&1)
+    echo "File name: $bam_markduplicates Picard version "\$(java -Xmx2g -jar \$PICARD_HOME/picard.jar  MarkDuplicates --version 2>&1)
     """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -385,7 +385,7 @@ process markDuplicates {
     output:
     file '*.markDups.bam' into bam_md
     file '*markDups_metrics.txt' into picard_results
-    file 'versioninfo.txt'
+    
     script:
     """
     java -Xmx2g -jar \$PICARD_HOME/picard.jar MarkDuplicates \\

--- a/main.nf
+++ b/main.nf
@@ -352,12 +352,12 @@ process preseq {
     file bam_preseq
     
     output:
-    file '*.txt' into preseq_results
+    file '*.ccurve.txt' into preseq_results
     
     script:
     """
     preseq lc_extrap -v -B $bam_preseq -o ${bam_preseq}.ccurve.txt
-    echo "File name: $bam_preseq ----- preseq version: "$(preseq)
+    echo "File name: $bam_preseq  preseq version: "\$(preseq)
     """
 }
 
@@ -398,7 +398,7 @@ process markDuplicates {
         VALIDATION_STRINGENCY=LENIENT
 
     #Printing out version number to standard out
-    echo "File name: $bam_markduplicates MarkDuplicates version "$(java -Xmx2g -jar $PICARD_HOME/picard.jar  MarkDuplicates --version 2>&1)
+    echo "File name: $bam_markduplicates MarkDuplicates version "\$(java -Xmx2g -jar \$PICARD_HOME/picard.jar  MarkDuplicates --version 2>&1)
     """
 }
 
@@ -549,7 +549,7 @@ process stringtieFPKM {
         -e \\
         -b ${bam_stringtieFPKM}_ballgown
 
-    echo "Stringtie version "$(stringtie --version)
+    echo "File name: $bam_stringtieFPKM Stringtie version "\$(stringtie --version)
     """
 }
 def num_bams
@@ -675,6 +675,7 @@ process sample_correlation {
     file.create("corr.done")
 
     #Printing sessioninfo to standard out
+    print("Sample correlation info:")
     sessionInfo()
     """
 }

--- a/main.nf
+++ b/main.nf
@@ -325,7 +325,7 @@ process rseqc {
     geneBody_coverage.py -i ${bam_rseqc} -o ${bam_rseqc}.rseqc -r $bed12
     read_distribution.py -i $bam_rseqc -r $bed12 > ${bam_rseqc}.read_distribution.txt
     read_duplication.py -i $bam_rseqc -o ${bam_rseqc}.read_duplication
-    echo "Filename $bam_rseqc RseQC version: "$(read_duplication.py --version)
+    echo "Filename $bam_rseqc RseQC version: "\$(read_duplication.py --version)
     """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -325,6 +325,7 @@ process rseqc {
     geneBody_coverage.py -i ${bam_rseqc} -o ${bam_rseqc}.rseqc -r $bed12
     read_distribution.py -i $bam_rseqc -r $bed12 > ${bam_rseqc}.read_distribution.txt
     read_duplication.py -i $bam_rseqc -o ${bam_rseqc}.read_duplication
+    echo "Filename $bam_rseqc RseQC version: "$(read_duplication.py --version)
     """
 }
 
@@ -351,11 +352,12 @@ process preseq {
     file bam_preseq
     
     output:
-    file '*.ccurve.txt' into preseq_results
+    file '*.txt' into preseq_results
     
     script:
     """
     preseq lc_extrap -v -B $bam_preseq -o ${bam_preseq}.ccurve.txt
+    echo "File name: $bam_preseq ----- preseq version: "$(preseq)
     """
 }
 
@@ -383,7 +385,7 @@ process markDuplicates {
     output:
     file '*.markDups.bam' into bam_md
     file '*markDups_metrics.txt' into picard_results
-    
+    file 'versioninfo.txt'
     script:
     """
     java -Xmx2g -jar \$PICARD_HOME/picard.jar MarkDuplicates \\
@@ -394,6 +396,9 @@ process markDuplicates {
         ASSUME_SORTED=true \\
         PROGRAM_RECORD_ID='null' \\
         VALIDATION_STRINGENCY=LENIENT
+
+    #Printing out version number to standard out
+    echo "File name: $bam_markduplicates MarkDuplicates version "$(java -Xmx2g -jar $PICARD_HOME/picard.jar  MarkDuplicates --version 2>&1)
     """
 }
 
@@ -460,6 +465,10 @@ process dupradar {
     expressionHist(DupMat=dm)
     title("Distribution of RPK values per gene")
     dev.off()
+    
+    #Printing sessioninfo to standard out
+    print("$bam_md")
+    sessionInfo()
     """
 
 }
@@ -539,6 +548,8 @@ process stringtieFPKM {
         -C ${bam_stringtieFPKM}.cov_refs.gtf \\
         -e \\
         -b ${bam_stringtieFPKM}_ballgown
+
+    echo "Stringtie version "$(stringtie --version)
     """
 }
 def num_bams
@@ -662,6 +673,9 @@ process sample_correlation {
     write.table(hmap\$carpet, 'log2CPM_sample_distances.txt', quote=FALSE, sep="\t")
     
     file.create("corr.done")
+
+    #Printing sessioninfo to standard out
+    sessionInfo()
     """
 }
 


### PR DESCRIPTION
We decided that it would be a good idea to inform the user of what version of a software that was used in the analysis and some of the software in the pipeline don't include the version number in their log file. 

This is now printed to standard out so that @ewels can write a module for the NGI-plugin for MultiQC to pick these up and display them in the report. 