### PR TITLE
Add a tag to sample_correlation and MultiQC processes

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -698,6 +698,7 @@ bam_count.count().subscribe{ num_bams = it }
  */
 process sample_correlation {
     publishDir "${params.outdir}/sample_correlation", mode: 'copy'
+    tag "$prefix"
 
     input:
     file input_files from geneCounts.toList()
@@ -711,6 +712,8 @@ process sample_correlation {
 
     script: // This script is bundled with the pipeline, in NGI-RNAseq/bin/
     def rlocation = params.rlocation ?: ''
+    prefix = reads[0].toString() - ~/(_R1)?(_trimmed)?(_val_1)?(\.fq)?(\.fastq)?(\.gz)?P\d+(_\d+)?$/
+    
     """
     edgeR_heatmap_MDS.r "rlocation=$rlocation" $input_files
     """
@@ -721,6 +724,8 @@ process sample_correlation {
  * STEP 11 MultiQC
  */
 process multiqc {
+    tag "$prefix"
+    
     publishDir "${params.outdir}/MultiQC", mode: 'copy'
 
     input:
@@ -740,6 +745,7 @@ process multiqc {
     file "*multiqc_data"
 
     script:
+    prefix = reads[0].toString() - ~/(_R1)?(_trimmed)?(_val_1)?(\.fq)?(\.fastq)?(\.gz)?P\d+(_\d+)?$/
     """
     multiqc -f .
     """

--- a/main.nf
+++ b/main.nf
@@ -712,7 +712,7 @@ process sample_correlation {
 
     script: // This script is bundled with the pipeline, in NGI-RNAseq/bin/
     def rlocation = params.rlocation ?: ''
-    prefix = reads[0].toString() - ~/(_R1)?(_trimmed)?(_val_1)?(\.fq)?(\.fastq)?(\.gz)?P\d+(_\d+)?$/
+    prefix = reads[0].toString() - ~/(_R1)?(_trimmed)?(_val_1)?(\.fq)?(\.fastq)?(\.gz)?$/
     
     """
     edgeR_heatmap_MDS.r "rlocation=$rlocation" $input_files
@@ -745,7 +745,7 @@ process multiqc {
     file "*multiqc_data"
 
     script:
-    prefix = reads[0].toString() - ~/(_R1)?(_trimmed)?(_val_1)?(\.fq)?(\.fastq)?(\.gz)?P\d+(_\d+)?$/
+    prefix = reads[0].toString() - ~/(_R1)?(_trimmed)?(_val_1)?(\.fq)?(\.fastq)?(\.gz)?$/
     """
     multiqc -f .
     """


### PR DESCRIPTION
This borrows the expression from the STAR process and uses the basename of the first file in the list as a tag for these processes. 

This is based on the NGI naming convention, but I think that should be fine. Either the user will end up with nothing as the tag (currently the case) or with the basename, which should be fine. 
I haven't tested it though since our cluster is down a the moment. 