### PR TITLE
Removed executor:'local' from config files.

### DIFF
--- a/conf/amazon_test.config
+++ b/conf/amazon_test.config
@@ -20,7 +20,6 @@ params {
 }
 
 process {
-  executor = 'local'
   cpus = 4
   memory = 15.GB
   time = 48.h

--- a/conf/base.config
+++ b/conf/base.config
@@ -12,7 +12,8 @@ vim: syntax=groovy
  */
 
 process {
-  executor = 'local'
+  // Remember to configure `executor` in your personal config file
+  // otherwise, Nextflow defaults to 'local' and runs on the head node
   cpus = 2
   memory = 8.GB
   time = 2.h

--- a/conf/docker.config
+++ b/conf/docker.config
@@ -17,7 +17,6 @@ docker {
 
 process {
   container = 'scilifelab/ngi-rnaseq'
-  executor = 'local'
   cpus = 1
   memory = 16.GB
   time = 48.h

--- a/conf/testing.config
+++ b/conf/testing.config
@@ -16,7 +16,6 @@ docker {
 }
 process {
   container = 'scilifelab/ngi-rnaseq'
-  executor = 'local'
   cpus = 2
   memory = 7.GB
   time = 48.h

--- a/conf/uppmax-devel.config
+++ b/conf/uppmax-devel.config
@@ -91,7 +91,7 @@ process {
     cpus = { 2 * task.attempt }
     memory = { 16.GB * task.attempt }
   }
-  // NB: Overwrite this in your user config file (~/.nextflow/config)
+  // NB: Overwrite this in a config file in the working directory (nextflow.config) or with -c
   // if you have your own installation of MultiQC outside of the environment module system.
   // eg: Add the line: params.$multiqc.module = ''
   $multiqc {

--- a/conf/uppmax.config
+++ b/conf/uppmax.config
@@ -95,7 +95,7 @@ process {
     cpus = { 2 * task.attempt }
     memory = { 16.GB * task.attempt }
   }
-  // NB: Overwrite this in your user config file (~/.nextflow/config)
+  // NB: Overwrite this in a config file in the working directory (nextflow.config) or with -c
   // if you have your own installation of MultiQC outside of the environment module system.
   // eg: Add the line: params.$multiqc.module = ''
   $multiqc {


### PR DESCRIPTION
`local` is [the default](https://www.nextflow.io/docs/latest/executor.html#local) nextflow executor, so will be used if nothing else is specified. I've removed this from `base` config and others that used it - should be no change, however it allows the person running the pipeline to override this by specifying the `executor` in their `~/.nextflow/config` file.