### PR TITLE
Require --singleEnd for SE input. MultiQC config through a channel.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # NGI-RNAseq
 ## 1.0.5dev
+* Summary HTML report now created upon pipeline completion
+  * This is saved in the results folder and also e-mailed if `--email` is set.
 * Made sure that the `.bam` files ended up in the main STAR directory when `--saveAlignedIntermediates` is used, instead of `STAR/logs`
+* Pipeline assumes that it's running with Paired-end files now
+  * An error is now raised if the file glob doesn't give pairs of files
+  * If running with single-end data, use the `--singleEnd` command-line option.
+* Made MultiQC load its config file through a channel instead of directly copying from `baseDir`
+* Timelines and traces now created by default for the testing configs
+* New configs and documentation about running the pipeline on AWS
 
 
 ## [1.0.4](https://github.com/SciLifeLab/NGI-RNAseq/releases/tag/1.0.4) - 2017-04-21

--- a/conf/aws.config
+++ b/conf/aws.config
@@ -57,7 +57,7 @@ process {
 
 params {
   saveReference = true
-  // illumina iGenomes reference file paths on UPPMAX
+  // illumina iGenomes reference file paths on S3
   genomes {
     'GRCh37' {
       bed12   = 's3://ngi-igenomes/igenomes/Homo_sapiens/Ensembl/GRCh37/Annotation/Genes/genes.bed'

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -25,10 +25,18 @@ Location of the input FastQ files:
 
 **NB: Must be enclosed in quotes!**
 
-Note that the `{1,2}` parentheses are required to specify paired end data. Running `--reads '*.fastq'` will treat
-all files as single end. The file path should be in quotation marks to prevent shell glob expansion.
+Note that the `{1,2}` parentheses are required to specify paired end data. The file path should be
+in quotation marks to prevent shell glob expansion.
 
-If left unspecified, the pipeline will assume that the data is in a directory called `data` in the working directory.
+If left unspecified, the pipeline will assume that the data is in a directory called `data` in the
+working directory (`data/*{1,2}.fastq.gz`).
+
+### `--singleEnd`
+By default, the pipeline expects paired-end data. If you have single-end data, specify `--singleEnd`
+on the command line when you launch the pipeline. A normal glob pattern, enclosed in quotation marks,
+can then be used for `--reads`. For example: `--singleEnd --reads '*.fastq'`
+
+It is not possible to run a mixture of single-end and paired-end files in one run.
 
 ### Library strandedness
 Three command line flags / config parameters set the library strandedness for a run:

--- a/main.nf
+++ b/main.nf
@@ -35,6 +35,7 @@ params.fasta = params.genome ? params.genomes[ params.genome ].fasta ?: false : 
 params.gtf = params.genome ? params.genomes[ params.genome ].gtf ?: false : false
 params.bed12 = params.genome ? params.genomes[ params.genome ].bed12 ?: false : false
 params.hisat2_index = params.genome ? params.genomes[ params.genome ].hisat2 ?: false : false
+params.multiqc_config = "$baseDir/conf/multiqc_config.yaml"
 params.splicesites = false
 params.download_hisat2index = false
 params.download_fasta = false
@@ -54,6 +55,7 @@ if (params.rlocation){
     nxtflow_libs.mkdirs()
 }
 
+multiqc_config = file(params.multiqc_config)
 
 def single
 params.sampleLevel = false
@@ -858,6 +860,7 @@ process multiqc {
     echo true
 
     input:
+    file multiqc_config
     file (fastqc:'fastqc/*') from fastqc_results.collect()
     file ('trimgalore/*') from trimgalore_results.collect()
     file ('alignment/*') from alignment_logs.collect()
@@ -877,8 +880,7 @@ process multiqc {
     script:
     prefix = fastqc[0].toString() - '_fastqc.html' - 'fastqc/'
     """
-    cp $baseDir/conf/multiqc_config.yaml multiqc_config.yaml
-    multiqc -f . 2>&1
+    multiqc -f -c $multiqc_config . 2>&1
     """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -56,8 +56,6 @@ if (params.rlocation){
 }
 
 multiqc_config = file(params.multiqc_config)
-
-def single
 params.sampleLevel = false
 
 // Custom trimming options
@@ -123,13 +121,25 @@ if( params.aligner == 'hisat2' && params.splicesites ){
 }
 if( workflow.profile == 'standard' && !params.project ) exit 1, "No UPPMAX project ID found! Use --project"
 
+
+/*
+ * Create a channel for input read files
+ */
+params.singleEnd = false
+Channel
+    .fromFilePairs( params.reads, size: params.singleEnd ? 1 : 2 )
+    .ifEmpty { exit 1, "Cannot find any reads matching: ${params.reads}\nIf this is single-end data, please specify --singleEnd on the command line." }
+    .into { read_files_fastqc; read_files_trimming }
+
+
 // Header log info
 log.info "========================================="
 log.info " NGI-RNAseq : RNA-Seq Best Practice v${version}"
 log.info "========================================="
 def summary = [:]
-summary['Reads']    = params.reads
-summary['Genome']   = params.genome
+summary['Reads']     = params.reads
+summary['Data Type'] = params.singleEnd ? 'Single-End' : 'Paired-End'
+summary['Genome']    = params.genome
 if(params.aligner == 'star'){
     summary['Aligner'] = "STAR"
     if(params.star_index)          summary['STAR Index']   = params.star_index
@@ -168,13 +178,6 @@ if(params.email) summary['E-mail Address'] = params.email
 log.info summary.collect { k,v -> "${k.padRight(15)}: $v" }.join("\n")
 log.info "========================================="
 
-/*
- * Create a channel for input read files
- */
-Channel
-    .fromFilePairs( params.reads, size: -1 )
-    .ifEmpty { exit 1, "Cannot find any reads matching: ${params.reads}" }
-    .into { read_files_fastqc; read_files_trimming }
 
 /*
  * PREPROCESSING - Download Fasta
@@ -403,12 +406,11 @@ process trim_galore {
     file "*_fastqc.{zip,html}" into trimgalore_fastqc_reports
 
     script:
-    single = reads instanceof Path
     c_r1 = params.clip_r1 > 0 ? "--clip_r1 ${params.clip_r1}" : ''
     c_r2 = params.clip_r2 > 0 ? "--clip_r2 ${params.clip_r2}" : ''
     tpc_r1 = params.three_prime_clip_r1 > 0 ? "--three_prime_clip_r1 ${params.three_prime_clip_r1}" : ''
     tpc_r2 = params.three_prime_clip_r2 > 0 ? "--three_prime_clip_r2 ${params.three_prime_clip_r2}" : ''
-    if (single) {
+    if (params.singleEnd) {
         """
         trim_galore --fastqc --gzip $c_r1 $tpc_r1 $reads
         """
@@ -509,11 +511,11 @@ if(params.aligner == 'hisat2'){
         prefix = reads[0].toString() - ~/(_R1)?(_trimmed)?(_val_1)?(\.fq)?(\.fastq)?(\.gz)?$/
         def rnastrandness = ''
         if (params.forward_stranded && !params.unstranded){
-            rnastrandness = single ? '--rna-strandness F' : '--rna-strandness FR'
+            rnastrandness = params.singleEnd ? '--rna-strandness F' : '--rna-strandness FR'
         } else if (params.reverse_stranded && !params.unstranded){
-            rnastrandness = single ? '--rna-strandness R' : '--rna-strandness RF'
+            rnastrandness = params.singleEnd ? '--rna-strandness R' : '--rna-strandness RF'
         }
-        if (single) {
+        if (params.singleEnd) {
             """
             set -o pipefail   # Capture exit codes from HISAT2, not samtools
             hisat2 -x $index_base \\
@@ -611,9 +613,9 @@ process rseqc {
     script:
     def strandRule = ''
     if (params.forward_stranded && !params.unstranded){
-        strandRule = single ? '-d ++,--' : '-d 1++,1--,2+-,2-+'
+        strandRule = params.singleEnd ? '-d ++,--' : '-d 1++,1--,2+-,2-+'
     } else if (params.reverse_stranded && !params.unstranded){
-        strandRule = single ? '-d +-,-+' : '-d 1+-,1-+,2++,2--'
+        strandRule = params.singleEnd ? '-d +-,-+' : '-d 1+-,1-+,2++,2--'
     }
     """
     samtools index $bam_rseqc
@@ -714,7 +716,7 @@ process dupradar {
     file "*.{pdf,txt}" into dupradar_results
 
     script: // This script is bundled with the pipeline, in NGI-RNAseq/bin/
-    def paired = single ? 'FALSE' :  'TRUE'
+    def paired = params.singleEnd ? 'FALSE' :  'TRUE'
     def rlocation = params.rlocation ?: ''
     """
     dupRadar.r $bam_md $gtf $paired $rlocation

--- a/main.nf
+++ b/main.nf
@@ -137,9 +137,10 @@ log.info "========================================="
 log.info " NGI-RNAseq : RNA-Seq Best Practice v${version}"
 log.info "========================================="
 def summary = [:]
-summary['Reads']     = params.reads
-summary['Data Type'] = params.singleEnd ? 'Single-End' : 'Paired-End'
-summary['Genome']    = params.genome
+summary['Reads']        = params.reads
+summary['Data Type']    = params.singleEnd ? 'Single-End' : 'Paired-End'
+summary['Strandedness'] = ( params.unstranded ? 'None' : params.forward_stranded ? 'Forward' : params.reverse_stranded ? 'Reverse' : 'None' )
+summary['Genome']       = params.genome
 if(params.aligner == 'star'){
     summary['Aligner'] = "STAR"
     if(params.star_index)          summary['STAR Index']   = params.star_index
@@ -156,7 +157,6 @@ if(params.aligner == 'star'){
 if(params.gtf)                 summary['GTF Annotation']  = params.gtf
 else if(params.download_gtf)   summary['GTF URL']         = params.download_gtf
 if(params.bed12)               summary['BED Annotation']  = params.bed12
-summary['Strandedness']   = ( params.unstranded ? 'None' : params.forward_stranded ? 'Forward' : params.reverse_stranded ? 'Reverse' : 'None' )
 summary['Current home']   = "$HOME"
 summary['Current user']   = "$USER"
 summary['Current path']   = "$PWD"

--- a/tests/amazon_test.sh
+++ b/tests/amazon_test.sh
@@ -32,7 +32,7 @@ else
     echo "Done"
 fi
 
-cmd="nextflow run $script_path -resume -profile amazon_test --reads \"${data_dir}/*.fastq.gz\""
+cmd="nextflow run $script_path -resume -profile amazon_test --singleEnd --reads \"${data_dir}/*.fastq.gz\""
 echo "Starting nextflow... Command:"
 echo $cmd
 echo "-----"

--- a/tests/docker_test.sh
+++ b/tests/docker_test.sh
@@ -32,7 +32,7 @@ else
     echo "Done"
 fi
 
-cmd="nextflow run $script_path -resume -profile testing --gtf ${data_dir}/genes.gtf --bed12 ${data_dir}/genes.bed --star_index ${data_dir}/star/ --reads \"${data_dir}/*.fastq.gz\""
+cmd="nextflow run $script_path -resume -profile testing --gtf ${data_dir}/genes.gtf --bed12 ${data_dir}/genes.bed --star_index ${data_dir}/star/ --singleEnd --reads \"${data_dir}/*.fastq.gz\""
 echo "Starting nextflow... Command:"
 echo $cmd
 echo "-----"

--- a/tests/docker_test_hisat.sh
+++ b/tests/docker_test_hisat.sh
@@ -32,7 +32,7 @@ else
     echo "Done"
 fi
 
-cmd="nextflow run $script_path -resume -profile testing --gtf ${data_dir}/genes.gtf --bed12 ${data_dir}/genes.bed --hisat2_index ${data_dir}/r64/ --aligner hisat2 --reads \"${data_dir}/*.fastq.gz\""
+cmd="nextflow run $script_path -resume -profile testing --gtf ${data_dir}/genes.gtf --bed12 ${data_dir}/genes.bed --hisat2_index ${data_dir}/r64/ --aligner hisat2 --singleEnd --reads \"${data_dir}/*.fastq.gz\""
 echo "Starting nextflow... Command:"
 echo $cmd
 echo "-----"

--- a/tests/uppmax_test.sh
+++ b/tests/uppmax_test.sh
@@ -31,7 +31,7 @@ else
     echo "Done"
 fi
 
-cmd="nextflow run $script_path -resume -profile devel --gtf ${data_dir}/genes.gtf --bed12 ${data_dir}/genes.bed --star_index ${data_dir}/star/ --reads \"${data_dir}/*.fastq.gz\""
+cmd="nextflow run $script_path -resume -profile devel --gtf ${data_dir}/genes.gtf --bed12 ${data_dir}/genes.bed --star_index ${data_dir}/star/ --singleEnd --reads \"${data_dir}/*.fastq.gz\""
 echo "Starting nextflow... Command:"
 echo $cmd
 echo "-----"


### PR DESCRIPTION
In NGI-MethylSeq I was having problems copying in the MultiQC config file directly from `$baseDir`, so thought it was a bit better practice to take it as a (configurable) input channel instead.

Secondly - added new `params.singleEnd`. Assumes PE if not given. This means that it's harder to accidentally run in SE mode with PE data. Also can't mix+match, or run with groupings of > 2 files or other crazy stuff.