### PR TITLE
MultiQC: run locally, use -name for report title and filename.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # NGI-RNAseq
 
+## 1.2dev
+
+* MultiQC now runs using `local` instead of `slurm` with default config
+  * Means that it stands a better chance of getting information from a remote database with plugins
+* MultiQC now uses the workflow name for report title and filename if specified
+
+
 ## [1.1](https://github.com/SciLifeLab/NGI-RNAseq/releases/tag/1.1) - 2017-05-23
 New release of the pipeline with a few additions:
 

--- a/conf/uppmax-devel.config
+++ b/conf/uppmax-devel.config
@@ -99,7 +99,7 @@ process {
   // if you have your own installation of MultiQC outside of the environment module system.
   // eg: Add the line: process.$multiqc.module = []
   $multiqc {
-    module = ['bioinfo-tools', 'MultiQC/0.9']
+    module = ['bioinfo-tools', 'MultiQC/1.0']
     errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }
   }
 }

--- a/conf/uppmax.config
+++ b/conf/uppmax.config
@@ -99,7 +99,8 @@ process {
   // if you have your own installation of MultiQC outside of the environment module system.
   // eg: Add the line: process.$multiqc.module = []
   $multiqc {
-    module = ['bioinfo-tools', 'MultiQC/0.9']
+    module = ['bioinfo-tools', 'MultiQC/1.0']
+    executor = 'local'
     errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }
   }
 }

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -195,6 +195,8 @@ to run on the development node (though won't work with default process time requ
 ### `-name`
 Name for the pipeline run. If not specified, Nextflow will automatically generate a random mnemonic.
 
+This is used in the MultiQC report (if not default) and in the summary HTML / e-mail (always).
+
 **NB:** Single hyphen (core Nextflow option)
 
 ### `-c`

--- a/tests/docker_test.sh
+++ b/tests/docker_test.sh
@@ -32,7 +32,9 @@ else
     echo "Done"
 fi
 
-cmd="nextflow run $script_path -resume -profile testing --gtf ${data_dir}/genes.gtf --bed12 ${data_dir}/genes.bed --star_index ${data_dir}/star/ --singleEnd --reads \"${data_dir}/*.fastq.gz\""
+run_name="Test RNA Run: "$(date +%s)
+
+cmd="nextflow run $script_path -resume -name \"$run_name\" -profile testing --gtf ${data_dir}/genes.gtf --bed12 ${data_dir}/genes.bed --star_index ${data_dir}/star/ --singleEnd --reads \"${data_dir}/*.fastq.gz\""
 echo "Starting nextflow... Command:"
 echo $cmd
 echo "-----"

--- a/tests/docker_test_hisat.sh
+++ b/tests/docker_test_hisat.sh
@@ -32,7 +32,9 @@ else
     echo "Done"
 fi
 
-cmd="nextflow run $script_path -resume -profile testing --gtf ${data_dir}/genes.gtf --bed12 ${data_dir}/genes.bed --hisat2_index ${data_dir}/r64/ --aligner hisat2 --singleEnd --reads \"${data_dir}/*.fastq.gz\""
+run_name="Test RNA Run: "$(date +%s)
+
+cmd="nextflow run $script_path -resume -name \"$run_name\" -profile testing --gtf ${data_dir}/genes.gtf --bed12 ${data_dir}/genes.bed --hisat2_index ${data_dir}/r64/ --aligner hisat2 --singleEnd --reads \"${data_dir}/*.fastq.gz\""
 echo "Starting nextflow... Command:"
 echo $cmd
 echo "-----"

--- a/tests/uppmax_test.sh
+++ b/tests/uppmax_test.sh
@@ -31,7 +31,9 @@ else
     echo "Done"
 fi
 
-cmd="nextflow run $script_path -resume -profile devel --gtf ${data_dir}/genes.gtf --bed12 ${data_dir}/genes.bed --star_index ${data_dir}/star/ --singleEnd --reads \"${data_dir}/*.fastq.gz\""
+run_name="Test RNA Run: "$(date +%s)
+
+cmd="nextflow run $script_path -resume -name \"$run_name\" -profile devel --gtf ${data_dir}/genes.gtf --bed12 ${data_dir}/genes.bed --star_index ${data_dir}/star/ --singleEnd --reads \"${data_dir}/*.fastq.gz\""
 echo "Starting nextflow... Command:"
 echo $cmd
 echo "-----"


### PR DESCRIPTION
This PR updates the MultiQC version loaded on uppmax and makes the process run locally instead of using SLURM for UPPMAX. This is because Irma compute nodes don't have an internet connection, which is needed for communication with statusdb.

Also made MultiQC use the workflow name for the report title and filename if specified. This is nice when the NGI plugin isn't installed / MultiQC can't contact statusdb.