### PR TITLE
Bugfixing params overwriting and fixing --pico

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 # NGI-RNAseq
 
-## 1.2dev
+## 1.2
 
 * MultiQC now runs using `local` instead of `slurm` with default config
   * Means that it stands a better chance of getting information from a remote database with plugins
 * MultiQC now uses the workflow name for report title and filename if specified
+* Fixed error where trimming parameters weren't set properly for `--pico`
+* Made pipeline run in forward-stranded mode when using `--pico`
 
 
 ## [1.1](https://github.com/SciLifeLab/NGI-RNAseq/releases/tag/1.1) - 2017-05-23

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -45,8 +45,7 @@ Three command line flags / config parameters set the library strandedness for a 
 * `--reverse_stranded`
 * `--unstranded`
 
-If not set, the pipeline will be run as unstranded. The UPPMAX configuration file sets `reverse_stranded` to true by default.
-Use `--unstranded` or `--forward_stranded` to overwrite this.
+If not set, the pipeline will be run as unstranded. The UPPMAX configuration file sets `reverse_stranded` to true by default. Use `--unstranded` or `--forward_stranded` to overwrite this. Specifying `--pico` makes the pipeline run in `forward_stranded` mode.
 
 These flags affect the commands used for several steps in the pipeline - namely HISAT2, featureCounts, RSeQC (`RPKM_saturation.py`)
 and StringTie:
@@ -145,22 +144,30 @@ If specific additional trimming is required (for example, from additional tags),
 you can use any of the following command line parameters. These affect the command
 used to launch TrimGalore!
 
-* `--clip_r1 [int]`
-  * Instructs Trim Galore to remove bp from the 5' end of read 1 (or single-end reads).
-* `--clip_r2 [int]`
-  * Instructs Trim Galore to remove bp from the 5' end of read 2 (paired-end reads only).
-* `--three_prime_clip_r1 [int]`
-  * Instructs Trim Galore to remove bp from the 3' end of read 1 _AFTER_ adapter/quality trimming has been performed.
-* `--three_prime_clip_r2 [int]`
-  * Instructs Trim Galore to re move bp from the 3' end of read 2 _AFTER_ adapter/quality trimming has been performed.
+### `--clip_r1 [int]`
+Instructs Trim Galore to remove bp from the 5' end of read 1 (or single-end reads).
 
-### Trimming Presets
-Some command line options are available to automatically set these trimming parameters
-for common RNA-seq library preparation kits.
+### `--clip_r2 [int]`
+Instructs Trim Galore to remove bp from the 5' end of read 2 (paired-end reads only).
 
-| Parameter | Kit                                             | 5' R1 | 5' R2 | 3' R1 | 3' R2 |
-|-----------|-------------------------------------------------|-------|-------|-------|-------|
-| `--pico`  | SMARTer Stranded Total RNA-Seq Kit - Pico Input | 3     | 0     | 0     | 3     |
+### `--three_prime_clip_r1 [int]`
+Instructs Trim Galore to remove bp from the 3' end of read 1 _AFTER_ adapter/quality trimming has been performed.
+
+### `--three_prime_clip_r2 [int]`
+Instructs Trim Galore to re move bp from the 3' end of read 2 _AFTER_ adapter/quality trimming has been performed.
+
+
+## Library Prep Presets
+Some command line options are available to automatically set parameters for common RNA-seq library preparation kits.
+
+> Note that these presets override other command line arguments. So if you specify `--pico --clip_r1 0`, the `--clip_r1` bit will be ignored.
+
+If you have a kit that you'd like a preset added for, please let us know!
+
+### `--pico`
+Sets trimming and standedness settings for the _SMARTer Stranded Total RNA-Seq Kit - Pico Input_ kit.
+
+Equivalent to: `--forward_stranded` `--clip_r1 3` `--three_prime_clip_r2 3`
 
 
 ## Job Resources

--- a/main.nf
+++ b/main.nf
@@ -22,7 +22,7 @@ vim: syntax=groovy
  */
 
 // Pipeline version
-version = '1.1'
+version = '1.2'
 
 // Configurable variables
 params.name = false


### PR DESCRIPTION
This fixes quite a nasty bug for the `--pico` command line flag. This hasn't been working at all, as `params.something` can't be overwritten in a pipeline script as they're special.

I've used regular NF variables here instead, which can be overwritten. Specifying `--pico` now _does_ set the trimming presets.

Some other changes to go along with it:

* Trimming presets always show, even if `0`
* `--pico` also sets `--forward_stranded`
* Use of variables makes sense when a config file sets a strandedness default but `--pico` is used on the command line.
* Updated the order of log messages when launching a run so that they flow a bit more naturally
* Added a couple of new log messages at the end of the pipeline

Phil