### PR TITLE
Made HTML email work properly. Added plaintext fallback.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 ## 1.3dev
 
-* Updated HISAT2 from v2.0.5 to v2.1.0 (UPPMAX environment module loading)
+* Updated HISAT2 from v2.0.5 to v2.1.0
+  * Uses `--new-summary` and `--summary-file` to give output that will work with MultiQC,
+  * UPPMAX environment module load and Docker image
+* Moved `pipefail` statement into config, applies to all processes
+* Rewrote summary e-mail commands. Now uses `sendmail`
+  * Also writes a plaintext summary. Falls back to sending this with `mail`
+* MultiQC process now runs using `local` executor for internet access on some UPPMAX clusters.
+* UPPMAX featureCounts process now loads `python/2.7.11` environment module
+* New test script for uppmax with HISAT2
 
 ## [1.2](https://github.com/SciLifeLab/NGI-RNAseq/releases/tag/1.2) - 2017-06-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
   * UPPMAX environment module load and Docker image
 * Moved `pipefail` statement into config, applies to all processes
 * Rewrote summary e-mail commands. Now uses `sendmail`
-  * Also writes a plaintext summary. Falls back to sending this with `mail`
+  * Proper multipart text/html e-mail with embedded images
+  * If sendmail fails, falls back to sending plaintext using `mail`
 * MultiQC process now runs using `local` executor for internet access on some UPPMAX clusters.
 * UPPMAX featureCounts process now loads `python/2.7.11` environment module
 * New test script for uppmax with HISAT2

--- a/assets/email_template.html
+++ b/assets/email_template.html
@@ -38,7 +38,7 @@
     </tbody>
 </table>
 
-<p>NGI-RNAseq is a bioinformatics best-practice analysis pipeline used for RNA sequencing data at the National Genomics Infastructure at SciLifeLab Stockholm, Sweden.</p>
+<p>NGI-RNAseq is a bioinformatics best-practice analysis pipeline used for RNA sequencing data at the National Genomics Infrastructure at SciLifeLab Stockholm, Sweden.</p>
 <p>The pipeline uses Nextflow, a bioinformatics workflow tool. It pre-processes raw data from FastQ inputs, aligns the reads and performs extensive quality-control on the results.</p>
 <p>For more information, please see the pipeline homepage: <a href="https://github.com/SciLifeLab/NGI-RNAseq">https://github.com/SciLifeLab/NGI-RNAseq</a></p>
 

--- a/assets/email_template.html
+++ b/assets/email_template.html
@@ -4,7 +4,7 @@
 <body>
 <div style="font-family: Helvetica, Arial, sans-serif; padding: 30px; max-width: 800px; margin: 0 auto;">
 
-<img src="data:image/png;base64,<% out << new File("${projectDir}/assets/NGI-RNAseq_logo.png").bytes.encodeBase64().toString() %>">
+<img src="cid:ngipipelinelogo">
 
 <h1>NGI-RNAseq: RNA-Seq Best Practice v${version}</h1>
 <h2>Run Name: $runName</h2>
@@ -44,8 +44,8 @@
 
 <hr style="height: 3px; padding: 0; margin: 24px 0; background-color: #e1e4e8; border: 0;">
 
-<img src="data:image/png;base64,<% out << new File("${projectDir}/assets/SciLifeLab_logo.png").bytes.encodeBase64().toString() %>">
-<img src="data:image/png;base64,<% out << new File("${projectDir}/assets/NGI_logo.png").bytes.encodeBase64().toString() %>">
+<img src="cid:scilifelablogo">
+<img src="cid:ngilogo">
 
 </div>
 

--- a/assets/email_template.txt
+++ b/assets/email_template.txt
@@ -1,0 +1,34 @@
+========================================
+ NGI-RNAseq: RNA-Seq Best Practice v${version}
+========================================
+Run Name: $runName
+
+<% if (success){
+    out << "## NGI-RNAseq execution completed successfully! ##"
+} else {
+    out << """####################################################
+## NGI-RNAseq execution completed unsuccessfully! ##
+####################################################
+The exit status of the task that caused the workflow execution to fail was: $exitStatus.
+The full error message was:
+
+${errorReport}
+"""
+} %>
+
+The workflow was completed at $dateComplete (duration: $duration)
+
+The command used to launch the workflow was as follows:
+
+  $commandLine
+
+
+
+Pipeline Configuration:
+-----------------------
+<% out << summary.collect{ k,v -> " - $k: $v" }.join("\n") %>
+
+--
+NGI-RNAseq is a bioinformatics best-practice analysis pipeline used for RNA sequencing data at the National Genomics Infrastructure at SciLifeLab Stockholm, Sweden.
+The pipeline uses Nextflow, a bioinformatics workflow tool. It pre-processes raw data from FastQ inputs, aligns the reads and performs extensive quality-control on the results.
+For more information, please see the pipeline homepage: https://github.com/SciLifeLab/NGI-RNAseq

--- a/assets/sendmail_template.html
+++ b/assets/sendmail_template.html
@@ -1,0 +1,38 @@
+To: $email
+Subject: $subject
+Mime-Version: 1.0
+Content-Type: multipart/alternative;boundary="ngimethylseqmimeboundary"
+
+--ngimethylseqmimeboundary
+Content-Type: text/plain; charset=utf-8
+
+$email_txt
+
+--ngimethylseqmimeboundary
+Content-Type: text/html; charset=utf-8
+
+$email_html
+
+--ngimethylseqmimeboundary
+Content-Type: image/png;name="NGI-RNAseq_logo.png"
+Content-Transfer-Encoding: base64
+Content-ID: <ngipipelinelogo>
+Content-Disposition: inline; filename="NGI-RNAseq_logo.png"
+
+<% out << new File("$baseDir/assets/NGI-RNAseq_logo.png").bytes.encodeBase64().toString() %>
+
+--ngimethylseqmimeboundary
+Content-Type: image/png;name="SciLifeLab_logo.png"
+Content-Transfer-Encoding: base64
+Content-ID: <scilifelablogo>
+Content-Disposition: inline; filename="SciLifeLab_logo.png"
+
+<% out << new File("$baseDir/assets/SciLifeLab_logo.png").bytes.encodeBase64().toString() %>
+
+--ngimethylseqmimeboundary
+Content-Type: image/png;name="NGI_logo.png"
+Content-Transfer-Encoding: base64
+Content-ID: <ngilogo>
+Content-Disposition: inline; filename="NGI_logo.png"
+
+<% out << new File("$baseDir/assets/NGI_logo.png").bytes.encodeBase64().toString() %>

--- a/main.nf
+++ b/main.nf
@@ -148,7 +148,7 @@ if( !(workflow.runName ==~ /[a-z]+_[a-z]+/) ){
 params.singleEnd = false
 Channel
     .fromFilePairs( params.reads, size: params.singleEnd ? 1 : 2 )
-    .ifEmpty { exit 1, "Cannot find any reads matching: ${params.reads}\nIf this is single-end data, please specify --singleEnd on the command line." }
+    .ifEmpty { exit 1, "Cannot find any reads matching: ${params.reads}\nNB: Path needs to be enclosed in quotes!\nIf this is single-end data, please specify --singleEnd on the command line." }
     .into { read_files_fastqc; read_files_trimming }
 
 

--- a/main.nf
+++ b/main.nf
@@ -538,7 +538,6 @@ if(params.aligner == 'hisat2'){
         }
         if (params.singleEnd) {
             """
-            set -o pipefail   # Capture exit codes from HISAT2, not samtools
             hisat2 -x $index_base \\
                    -U $reads \\
                    $rnastrandness \\
@@ -551,7 +550,6 @@ if(params.aligner == 'hisat2'){
             """
         } else {
             """
-            set -o pipefail   # Capture exit codes from HISAT2, not samtools
             hisat2 -x $index_base \\
                    -1 ${reads[0]} \\
                    -2 ${reads[1]} \\

--- a/nextflow.config
+++ b/nextflow.config
@@ -42,6 +42,9 @@ profiles {
 
 }
 
+// Capture exit codes from upstream processes when piping
+process.shell = ['/bin/bash', '-euo', 'pipefail']
+
 manifest {
   homePage = 'https://github.com/SciLifeLab/NGI-RNAseq'
   description = 'Nextflow RNA-Seq Best Practice analysis pipeline, used at the SciLifeLab National Genomics Infrastructure.'


### PR DESCRIPTION
Now using `sendmail` instead of `mail` for HTML e-mail as it seems to work properly on both UPPMAX and local OSX.