### PR TITLE
Singularity support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # NGI-RNAseq
+
 ## 1.4dev
+* Changed default config to base, **UPPMAX users now need to specify `-profile uppmax`**
+* Switched UPPMAX configuration to use Singularity instead of environment modules
 * Added a Troubleshooting section to the docs
+* Refactored config for `hebbe`
 
 ## [1.3.1](https://github.com/SciLifeLab/NGI-RNAseq/releases/tag/1.3.1) - 2017-10-16
 Hotfix to update version number in pipeline script.

--- a/Dockerfile
+++ b/Dockerfile
@@ -120,5 +120,5 @@ RUN git clone https://github.com/infphilo/hisat2.git /opt/hisat2 && \
     cp /opt/hisat2/hisat2 /opt/hisat2/hisat2-align-s /opt/hisat2/hisat2-align-l /opt/hisat2/hisat2-build /opt/hisat2/hisat2-build-s /opt/hisat2/hisat2-build-l /opt/hisat2/hisat2-inspect /opt/hisat2/hisat2-inspect-s /opt/hisat2/hisat2-inspect-l /usr/local/bin/ && \
     cp /opt/hisat2/*.py /usr/local/bin
 
-# Create UPPMAX directories
-RUN mkdir /pica /proj /scratch /sw
+# Create UPPMAX root directories
+RUN mkdir /pica /lupus /crex1 /crex2 /proj /scratch /sw

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,13 +83,13 @@ RUN curl -fsSL https://github.com/broadinstitute/picard/releases/download/2.0.1/
 ENV PICARD_HOME /opt/picard-tools-2.0.1
 
 # Install R
-RUN curl -fsSL https://cran.r-project.org/src/base/R-3/R-3.2.3.tar.gz -o /opt/R-3.2.3.tar.gz && \
-    tar xvzf /opt/R-3.2.3.tar.gz -C /opt/ && \
-    cd /opt/R-3.2.3 && \
+RUN curl -fsSL https://cran.r-project.org/src/base/R-3/R-3.4.2.tar.gz -o /opt/R-3.4.2.tar.gz && \
+    tar xvzf /opt/R-3.4.2.tar.gz -C /opt/ && \
+    cd /opt/R-3.4.2 && \
     ./configure && \
     make && \
     make install && \
-    rm /opt/R-3.2.3.tar.gz
+    rm /opt/R-3.4.2.tar.gz
 
 # Install R Packages v2
 RUN echo 'source("https://bioconductor.org/biocLite.R")' > /opt/packages.r && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,7 +74,7 @@ RUN curl -fsSL http://smithlabresearch.org/downloads/preseq_linux_v2.0.tar.bz2 -
     ln -s /opt/preseq_v2.0/bam2mr /usr/local/bin/bam2mr && \
     rm /opt/preseq_linux_v2.0.tar.bz2 && \
     # Make sure that libgsl.so.0 exists beause PreSeq links to that
-    ln -s /usr/lib/x86_64-linux-gnu/libgsl.so /lib/x86_64-linux-gnu/libgsl.so.0 
+    ln -s /usr/lib/x86_64-linux-gnu/libgsl.so /lib/x86_64-linux-gnu/libgsl.so.0
 
 # Install PicardTools
 RUN curl -fsSL https://github.com/broadinstitute/picard/releases/download/2.0.1/picard-tools-2.0.1.zip -o /opt/picard-tools-2.0.1.zip && \
@@ -119,3 +119,6 @@ RUN git clone https://github.com/infphilo/hisat2.git /opt/hisat2 && \
     make && \
     cp /opt/hisat2/hisat2 /opt/hisat2/hisat2-align-s /opt/hisat2/hisat2-align-l /opt/hisat2/hisat2-build /opt/hisat2/hisat2-build-s /opt/hisat2/hisat2-build-l /opt/hisat2/hisat2-inspect /opt/hisat2/hisat2-inspect-s /opt/hisat2/hisat2-inspect-l /usr/local/bin/ && \
     cp /opt/hisat2/*.py /usr/local/bin
+
+# Create UPPMAX directories
+RUN mkdir /pica /proj /scratch /sw

--- a/conf/aws.config
+++ b/conf/aws.config
@@ -14,7 +14,7 @@ docker {
 }
 
 process {
-  container = 'scilifelab/ngi-rnaseq'
+  container = wf_container
   executor = 'ignite'
 }
 

--- a/conf/docker.config
+++ b/conf/docker.config
@@ -16,7 +16,7 @@ docker {
 }
 
 process {
-  container = 'scilifelab/ngi-rnaseq'
+  container = wf_container
 }
 
 params {

--- a/conf/hebbe.config
+++ b/conf/hebbe.config
@@ -7,23 +7,15 @@ vim: syntax=groovy
  * http://www.c3se.chalmers.se/index.php/Hebbe
  *
  * NB: Required software must be installed manually.
- * See installation docs 3.2) Configuration: Other clusters
+ * See installation docs "Manual Installation"
  * for instructions on required setup steps to use this configuration.
- *
- * NOTE: Config only tested with Yeast data so far. If resources are
- * inadequate, please submit an issue: https://github.com/SciLifeLab/NGI-RNAseq/issues
+ * https://github.com/SciLifeLab/NGI-RNAseq/blob/master/docs/installation.md#manual-installation
  */
 
 process {
   executor = 'slurm'
   clusterOptions = { "-A $params.project ${params.clusterOptions ?: ''}" }
   cpus = 4
-}
-
-
-params {
-  clusterOptions = false
-  saveReference = true
 }
 
 params {

--- a/conf/hebbe.config
+++ b/conf/hebbe.config
@@ -19,7 +19,6 @@ process {
 }
 
 params {
-  clusterOptions = false
   saveReference = true
   max_memory = 64.GB
   max_cpus = 20

--- a/conf/testing.config
+++ b/conf/testing.config
@@ -15,7 +15,7 @@ docker {
   enabled = true
 }
 process {
-  container = 'scilifelab/ngi-rnaseq'
+  container = wf_container
   cpus = 2
   memory = 7.GB
   time = 48.h

--- a/conf/uppmax-modules.config
+++ b/conf/uppmax-modules.config
@@ -35,3 +35,7 @@ process {
   // eg: Add the line: process.$multiqc.module = []
   $multiqc.module = ['bioinfo-tools', 'MultiQC/1.3']
 }
+
+params {
+  rlocation = "$HOME/R/nxtflow_libs/"
+}

--- a/conf/uppmax-modules.config
+++ b/conf/uppmax-modules.config
@@ -1,0 +1,37 @@
+/*
+vim: syntax=groovy
+-*- mode: groovy;-*-
+ * -------------------------------------------------
+ *  Nextflow config file with environment modules for UPPMAX (milou / irma)
+ * -------------------------------------------------
+ */
+
+singularity {
+  enabled = false
+}
+
+process {
+
+  // Environment modules and resource requirements
+  $makeSTARindex.module = ['bioinfo-tools', 'star/2.5.1b']
+  $makeHisatSplicesites.module = ['bioinfo-tools', 'HISAT2/2.1.0']
+  $makeHISATindex.module = ['bioinfo-tools', 'HISAT2/2.1.0']
+  $fastqc.module = ['bioinfo-tools', 'FastQC/0.11.5']
+  $trim_galore.module = ['bioinfo-tools', 'FastQC/0.11.5', 'TrimGalore/0.4.1']
+  $star.module = ['bioinfo-tools', 'star/2.5.1b']
+  $hisat2Align.module = ['bioinfo-tools', 'samtools/1.3', 'HISAT2/2.1.0']
+  $hisat2_sortOutput.module = ['bioinfo-tools', 'samtools/1.3']
+  $rseqc.module = ['bioinfo-tools', 'rseqc/2.6.1', 'samtools/1.3']
+  $genebody_coverage.module = ['bioinfo-tools', 'rseqc/2.6.1', 'samtools/1.3']
+  $preseq.module = ['bioinfo-tools', 'preseq/0.1.0']
+  $markDuplicates.module = ['bioinfo-tools', 'samtools/1.3', 'picard/2.0.1']
+  $dupradar.module = ['bioinfo-tools', 'R/3.2.3']
+  $featureCounts.module = ['bioinfo-tools', 'subread/1.5.1']
+  $merge_featureCounts.module = ['python/2.7.11']
+  $stringtieFPKM.module = ['bioinfo-tools', 'StringTie/1.3.3']
+  $sample_correlation.module = ['bioinfo-tools', 'R/3.2.3']
+  // NB: Overwrite this in a config file in the working directory (nextflow.config) or with -c
+  // if you have your own installation of MultiQC outside of the environment module system.
+  // eg: Add the line: process.$multiqc.module = []
+  $multiqc.module = ['bioinfo-tools', 'MultiQC/1.3']
+}

--- a/conf/uppmax.config
+++ b/conf/uppmax.config
@@ -9,35 +9,15 @@ vim: syntax=groovy
  * profile in nextflow.config
  */
 
+singularity {
+  enabled = true
+}
+
 process {
   executor = 'slurm'
   clusterOptions = { "-A $params.project ${params.clusterOptions ?: ''}" }
-
-  // Environment modules and resource requirements
-  $makeSTARindex.module = ['bioinfo-tools', 'star/2.5.1b']
-  $makeHisatSplicesites.module = ['bioinfo-tools', 'HISAT2/2.1.0']
-  $makeHISATindex.module = ['bioinfo-tools', 'HISAT2/2.1.0']
-  $fastqc.module = ['bioinfo-tools', 'FastQC/0.11.5']
-  $trim_galore.module = ['bioinfo-tools', 'FastQC/0.11.5', 'TrimGalore/0.4.1']
-  $star.module = ['bioinfo-tools', 'star/2.5.1b']
-  $hisat2Align.module = ['bioinfo-tools', 'samtools/1.3', 'HISAT2/2.1.0']
-  $hisat2_sortOutput.module = ['bioinfo-tools', 'samtools/1.3']
-  $rseqc.module = ['bioinfo-tools', 'rseqc/2.6.1', 'samtools/1.3']
-  $genebody_coverage.module = ['bioinfo-tools', 'rseqc/2.6.1', 'samtools/1.3']
-  $preseq.module = ['bioinfo-tools', 'preseq/0.1.0']
-  $markDuplicates.module = ['bioinfo-tools', 'samtools/1.3', 'picard/2.0.1']
-  $dupradar.module = ['bioinfo-tools', 'R/3.2.3']
-  $featureCounts.module = ['bioinfo-tools', 'subread/1.5.1']
-  $merge_featureCounts.module = ['python/2.7.11']
-  $stringtieFPKM.module = ['bioinfo-tools', 'StringTie/1.3.3']
-  $sample_correlation.module = ['bioinfo-tools', 'R/3.2.3']
-  // NB: Overwrite this in a config file in the working directory (nextflow.config) or with -c
-  // if you have your own installation of MultiQC outside of the environment module system.
-  // eg: Add the line: process.$multiqc.module = []
-  $multiqc.module = ['bioinfo-tools', 'MultiQC/1.3']
+  container = 'docker://scilifelab/ngi-rnaseq'
 }
-
-
 
 params {
   clusterOptions = false

--- a/conf/uppmax.config
+++ b/conf/uppmax.config
@@ -22,6 +22,7 @@ process {
 params {
   saveReference = true
   reverse_stranded = true
+  rlocation = "/usr/local/lib/R/library"
   // Max resources requested by a normal node on milou. If you need more memory, run on a fat node using:
   //   --clusterOptions "-C mem512GB" --max_memory "512GB"
   max_memory = 128.GB

--- a/conf/uppmax.config
+++ b/conf/uppmax.config
@@ -16,7 +16,7 @@ singularity {
 process {
   executor = 'slurm'
   clusterOptions = { "-A $params.project ${params.clusterOptions ?: ''}" }
-  container = 'docker://scilifelab/ngi-rnaseq'
+  container = "docker://$wf_container"
 }
 
 params {

--- a/conf/uppmax.config
+++ b/conf/uppmax.config
@@ -20,8 +20,6 @@ process {
 }
 
 params {
-  clusterOptions = false
-  rlocation = "$HOME/R/nxtflow_libs/"
   saveReference = true
   reverse_stranded = true
   // Max resources requested by a normal node on milou. If you need more memory, run on a fat node using:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -34,17 +34,23 @@ See [nextflow.io](https://www.nextflow.io/) and [NGI-NextflowDocs](https://githu
 ## 2) Install the Pipeline
 This pipeline itself needs no installation - NextFlow will automatically fetch it from GitHub if `SciLifeLab/NGI-RNAseq` is specified as the pipeline name.
 
-If you prefer, you can download the files yourself from GitHub and run them directly:
+### Offline use
+
+If you need to run the pipeline on a system with no internet connection, you will need to download the files yourself from GitHub and run them directly:
 
 ```bash
-git clone https://github.com/SciLifeLab/NGI-RNAseq.git
-nextflow run NGI-RNAseq/main.nf
+wget https://github.com/SciLifeLab/NGI-RNAseq/archive/master.zip
+unzip master.zip -d /my-pipelines/
+cd /my_data/
+nextflow run /my-pipelines/NGI-RNAseq-master
 ```
 
 ## 3.1) Configuration: UPPMAX
-By default, the pipeline is configured to run on the [Swedish UPPMAX](https://www.uppmax.uu.se/) cluster (`milou` / `irma`). As such, you shouldn't need to add any custom configuration - everything _should_ work out of the box.
+The pipeline comes bundled with configurations to use the [Swedish UPPMAX](https://www.uppmax.uu.se/) clusters (tested on `milou`, `rackham`, `bianca` and `irma`). As such, you shouldn't need to add any custom configuration - everything _should_ work out of the box.
 
-Note that you will need to specify your UPPMAX project ID when running a pipeline. To do this, use the command line flag `--project <project_ID>`. The pipeline will exit with an error message if you try to run it pipeline with the default UPPMAX config profile without a project.
+To use the pipeline on UPPMAX, you **must** specificy `-profile uppmax` when running the pipeline (as of Nov 2017).
+
+Note that you will need to specify your UPPMAX project ID when running a pipeline. To do this, use the command line flag `--project <project_ID>`. The pipeline will exit with an error message if you try to run it pipeline with the UPPMAX config profile without a project.
 
 **Optional Extra:** To avoid having to specify your project every time you run Nextflow, you can add it to your personal Nextflow config file instead. Add this line to `~/.nextflow/config`:
 
@@ -64,10 +70,10 @@ It is entirely possible to run this pipeline on other clusters, though you will 
 
 If you are the only person to be running this pipeline, you can create your config file as `~/.nextflow/config` and it will be applied every time you run Nextflow. Alternatively, save the file anywhere and reference it when running the pipeline with `-c path/to/config`.
 
-A basic configuration comes with the pipeline, which should be applied by using the command line flag `-profile base`. This prevents the UPPMAX defaults (above) from being applied and means that you only need to configure the specifics for your system.
+A basic configuration comes with the pipeline, which runs by default (the `standard` config profile with [`conf/base.config`](../conf/base.config)). This means that you only need to configure the specifics for your system and overwrite any defaults that you want to change.
 
 ### Cluster Environment
-By default, the `base` profile uses the `local` Nextflow executor - in other words, all jobs are run in the login session. If you're using a simple server, this may be fine. If you're using a compute cluster, this is bad as all jobs will run on the head node.
+By default, pipeline uses the `local` Nextflow executor - in other words, all jobs are run in the login session. If you're using a simple server, this may be fine. If you're using a compute cluster, this is bad as all jobs will run on the head node.
 
 To specify your cluster environment, add the following line to your config file:
 
@@ -117,8 +123,38 @@ params {
 ### Software Requirements
 To run the pipeline, several software packages are required. How you satisfy these requirements is essentially up to you and depends on your system.
 
+#### Docker Image
+Docker is a software tool that allows you to run your analysis inside a "container" - basically a miniature self-contained software environment. We've already made a docker image for you, so if you can run docker and nextflow then you don't need to worry about any other software dependencies.
+
+The pipeline comes with a script to build a docker image. This runs automatically and creates a hosted docker image that you can find here: https://hub.docker.com/r/scilifelab/ngi-rnaseq/
+
+If you run the pipeline with `-profile docker` or `-with-docker 'scilifelab/ngi-rnaseq'` then nextflow will download this docker image automatically and run using this.
+
+Note that the docker images are tagged with version as well as the code, so this is a great way to ensure reproducibility. You can specify pipeline version when running with `-r`, for example `-r v1.3`. This uses pipeline code and docker image from this tagged version.
+
+#### Singularity image
+Many HPC environments are not able to run Docker due to problems with needing administrator privileges. [Singularity](http://singularity.lbl.gov/) is a tool designed to run on such HPC systems which is very similar to Docker. Even better, it can use create images directly from dockerhub. The UPPMAX configuration uses Singularity by default, meaning no problems with software dependencies and great reproducibility.
+
+To use the singularity image with a different config, use `-with-singularity 'docker://scilifelab/ngi-rnaseq'` when running the pipeline.
+
+If you intend to run the pipeline offline, nextflow will not be able to automatically download the singularity image for you. Instead, you'll have to do this yourself manually first, transfer the image file and then point to that.
+
+First, pull the image file where you have an internet connection:
+
+```bash
+singularity pull --name ngi-rnaseq.img docker://scilifelab/ngi-rnaseq
+```
+
+Then transfer this file and run the pipeline with this path:
+
+```
+nextflow run /path/to/NGI-RNAseq -with-singularity /path/to/ngi-rnaseq.img
+```
+
 #### Environment Modules
-If your cluster uses environment modules, the software may already be available. If so, just add lines to your custom config file as follows _(customise module names and versions as appropriate)_:
+If your cluster uses environment modules, you can use the pipeline with these. There is a bundled config file to use these on UPPMAX (as was done in earlier versions of this pipeline). To use this, run the pipeline with `-profile uppmax_modules`.
+
+If running on another system, add lines to your custom config file as follows _(customise module names and versions as appropriate)_:
 
 ```groovy
 process {

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -24,6 +24,23 @@ results         # Finished results (configurable, see below)
 # Other nextflow hidden files, eg. history of pipeline runs and old logs.
 ```
 
+### Updating the pipeline
+When you run the above command, Nextflow automatically pulls the pipeline code from GitHub and stores it as a cached version. When running the pipeline after this, it will always use the cached version if available - even if the pipeline has been updated since. To make sure that you're running the latest version of the pipeline, make sure that you regularly update the cached version of the pipeline:
+
+```bash
+nextflow pull scilifelab/ngi-rnaseq
+```
+
+### Reproducibility
+It's a good idea to specify a pipeline version when running the pipeline on your data. This ensures that a specific version of the pipeline code and software are used when you run your pipeline. If you keep using the same tag, you'll be running the same version of the pipeline, even if there have been changes to the code since.
+
+First, go to the [NGI-RNAseq releases page](https://github.com/SciLifeLab/NGI-RNAseq/releases) and find the latest version number - numeric only (eg. `1.3.1`). Then specify this when running the pipeline with `-r` (one hyphen) - eg. `-r 1.3.1`.
+
+This version number will be logged in reports when you run the pipeline, so that you'll know what you used when you look back in the future.
+
+
+## Main Arguments
+
 ### `--reads`
 Use this to specify the location of your input FastQ files. For example:
 

--- a/main.nf
+++ b/main.nf
@@ -206,7 +206,18 @@ if( params.aligner == 'hisat2' && params.splicesites ){
         .ifEmpty { exit 1, "HISAT2 splice sites file not found: $alignment_splicesites" }
         .into { indexing_splicesites; alignment_splicesites }
 }
-if( workflow.profile == 'standard' && !params.project ) exit 1, "No UPPMAX project ID found! Use --project"
+if( workflow.profile == 'standard'){
+    if ( "hostname".execute().text.contains('.uppmax.uu.se') ) {
+        log.error "============================================================\n" +
+                  "  WARNING! You are running with the default 'standard'\n" +
+                  "  pipeline config profile, which runs on the head node\n" +
+                  "  and assumes all software is on the PATH.\n" +
+                  "  Please use `-profile uppmax` to run on UPPMAX clusters.\n" +
+                  "============================================================"
+    }
+} else if( workflow.profile == 'uppmax' || workflow.profile == 'uppmax-modules' || workflow.profile == 'uppmax-devel' ){
+    if ( !params.project ) exit 1, "No UPPMAX project ID found! Use --project"
+}
 
 // Has the run name been specified by the user?
 //  this has the bonus effect of catching both -name and --name

--- a/main.nf
+++ b/main.nf
@@ -1199,4 +1199,18 @@ workflow.onComplete {
 
     log.info "[NGI-RNAseq] Pipeline Complete"
 
+    if(!workflow.success){
+        if( workflow.profile == 'standard'){
+            if ( "hostname".execute().text.contains('.uppmax.uu.se') ) {
+                log.error "====================================================\n" +
+                        "  WARNING! You are running with the default 'standard'\n" +
+                        "  pipeline config profile, which runs on the head node\n" +
+                        "  and assumes all software is on the PATH.\n" +
+                        "  This is probably why everything broke.\n" +
+                        "  Please use `-profile uppmax` to run on UPPMAX clusters.\n" +
+                        "============================================================"
+            }
+        }
+    }
+
 }

--- a/main.nf
+++ b/main.nf
@@ -25,11 +25,12 @@ def helpMessage() {
 
     The typical command for running the pipeline is as follows:
 
-    nextflow run SciLifeLab/NGI-RNAseq --reads '*_R{1,2}.fastq.gz' --genome GRCh37
+    nextflow run SciLifeLab/NGI-RNAseq --reads '*_R{1,2}.fastq.gz' --genome GRCh37 -profile uppmax
 
     Mandatory arguments:
       --reads                       Path to input data (must be surrounded with quotes)
       --genome                      Name of iGenomes reference
+      -profile                      Hardware config to use. uppmax / uppmax_modules / hebbe / docker / aws
 
     Options:
       --singleEnd                   Specifies that the input is single end reads
@@ -72,7 +73,7 @@ def helpMessage() {
  */
 
 // Pipeline version
-version = '1.3.1'
+version = '1.4dev'
 
 // Show help emssage
 params.help = false
@@ -249,6 +250,8 @@ summary['Save Trimmed']   = params.saveTrimmed ? 'Yes' : 'No'
 summary['Save Intermeds'] = params.saveAlignedIntermediates ? 'Yes' : 'No'
 summary['Output dir']     = params.outdir
 summary['Working dir']    = workflow.workDir
+summary['Container']      = workflow.container
+if(workflow.revision) summary['Pipeline Release'] = workflow.revision
 summary['Current home']   = "$HOME"
 summary['Current user']   = "$USER"
 summary['Current path']   = "$PWD"

--- a/main.nf
+++ b/main.nf
@@ -81,21 +81,6 @@ if (params.help){
     exit 0
 }
 
-// Check that Nextflow version is up to date enough
-// try / throw / catch works for NF versions < 0.25 when this was implemented
-nf_required_version = '0.25.0'
-try {
-    if( ! nextflow.version.matches(">= $nf_required_version") ){
-        throw GroovyException('Nextflow version too old')
-    }
-} catch (all) {
-    log.error "====================================================\n" +
-              "  Nextflow version $nf_required_version required! You are running v$workflow.nextflow.version.\n" +
-              "  Pipeline execution will continue, but things may break.\n" +
-              "  Please run `nextflow self-update` to update Nextflow.\n" +
-              "============================================================"
-}
-
 // Configurable variables
 params.name = false
 params.project = false
@@ -206,16 +191,7 @@ if( params.aligner == 'hisat2' && params.splicesites ){
         .ifEmpty { exit 1, "HISAT2 splice sites file not found: $alignment_splicesites" }
         .into { indexing_splicesites; alignment_splicesites }
 }
-if( workflow.profile == 'standard'){
-    if ( "hostname".execute().text.contains('.uppmax.uu.se') ) {
-        log.error "============================================================\n" +
-                  "  WARNING! You are running with the default 'standard'\n" +
-                  "  pipeline config profile, which runs on the head node\n" +
-                  "  and assumes all software is on the PATH.\n" +
-                  "  Please use `-profile uppmax` to run on UPPMAX clusters.\n" +
-                  "============================================================"
-    }
-} else if( workflow.profile == 'uppmax' || workflow.profile == 'uppmax-modules' || workflow.profile == 'uppmax-devel' ){
+if( workflow.profile == 'uppmax' || workflow.profile == 'uppmax-modules' || workflow.profile == 'uppmax-devel' ){
     if ( !params.project ) exit 1, "No UPPMAX project ID found! Use --project"
 }
 
@@ -278,11 +254,40 @@ summary['Current user']   = "$USER"
 summary['Current path']   = "$PWD"
 summary['R libraries']    = params.rlocation
 summary['Script dir']     = workflow.projectDir
-summary['Config Profile'] = (workflow.profile == 'standard' ? 'UPPMAX' : workflow.profile)
+summary['Config Profile'] = workflow.profile
 if(params.project) summary['UPPMAX Project'] = params.project
 if(params.email) summary['E-mail Address'] = params.email
 log.info summary.collect { k,v -> "${k.padRight(15)}: $v" }.join("\n")
 log.info "========================================="
+
+
+// Check that Nextflow version is up to date enough
+// try / throw / catch works for NF versions < 0.25 when this was implemented
+nf_required_version = '0.25.0'
+try {
+    if( ! nextflow.version.matches(">= $nf_required_version") ){
+        throw GroovyException('Nextflow version too old')
+    }
+} catch (all) {
+    log.error "====================================================\n" +
+              "  Nextflow version $nf_required_version required! You are running v$workflow.nextflow.version.\n" +
+              "  Pipeline execution will continue, but things may break.\n" +
+              "  Please run `nextflow self-update` to update Nextflow.\n" +
+              "============================================================"
+}
+
+// Show a big error message if we're running on the base config and an uppmax cluster
+if( workflow.profile == 'standard'){
+    if ( "hostname".execute().text.contains('.uppmax.uu.se') ) {
+        log.error "====================================================\n" +
+                  "  WARNING! You are running with the default 'standard'\n" +
+                  "  pipeline config profile, which runs on the head node\n" +
+                  "  and assumes all software is on the PATH.\n" +
+                  "  ALL JOBS ARE RUNNING LOCALLY and stuff will probably break.\n" +
+                  "  Please use `-profile uppmax` to run on UPPMAX clusters.\n" +
+                  "============================================================"
+    }
+}
 
 
 /*

--- a/nextflow.config
+++ b/nextflow.config
@@ -17,8 +17,9 @@ wf_container = "scilifelab/ngi-rnaseq:${container_tag}"
 
 // Global default params, used in configs
 params {
-    outdir = './results'
-    igenomes_base = "./iGenomes"
+  outdir = './results'
+  igenomes_base = "./iGenomes"
+  clusterOptions = false
 }
 
 profiles {

--- a/nextflow.config
+++ b/nextflow.config
@@ -29,7 +29,7 @@ profiles {
     includeConfig 'conf/uppmax-modules.config'
     includeConfig 'conf/igenomes.config'
   }
-  devel {
+  uppmax-devel {
     includeConfig 'conf/base.config'
     includeConfig 'conf/uppmax.config'
     includeConfig 'conf/uppmax-devel.config'

--- a/nextflow.config
+++ b/nextflow.config
@@ -15,6 +15,12 @@ vim: syntax=groovy
 container_tag = workflow.revision ? workflow.revision : 'latest'
 wf_container = "scilifelab/ngi-rnaseq:${container_tag}"
 
+// Global default params, used in configs
+params {
+    outdir = './results'
+    igenomes_base = "./iGenomes"
+}
+
 profiles {
 
   standard {
@@ -66,11 +72,6 @@ profiles {
 // Capture exit codes from upstream processes when piping
 process.shell = ['/bin/bash', '-euo', 'pipefail']
 
-// Global default params, used in configs
-params {
-    outdir = './results'
-    igenomes_base = "./iGenomes"
-}
 timeline {
   enabled = true
   file = "${params.outdir}/NGI-RNAseq_timeline.html"

--- a/nextflow.config
+++ b/nextflow.config
@@ -10,8 +10,10 @@ vim: syntax=groovy
  * name here.
  */
 
-//Placeholder for Igenomes
-params.igenomes_base = "./iGenomes"
+// Variable to specify the docker / singularity image tag to use
+// Picks up on use of -r 1.3 in nextflow command
+container_tag = workflow.revision ? workflow.revision : 'latest'
+wf_container = "scilifelab/ngi-rnaseq:${container_tag}"
 
 profiles {
 
@@ -64,7 +66,11 @@ profiles {
 // Capture exit codes from upstream processes when piping
 process.shell = ['/bin/bash', '-euo', 'pipefail']
 
-params.outdir = './results'
+// Global default params, used in configs
+params {
+    outdir = './results'
+    igenomes_base = "./iGenomes"
+}
 timeline {
   enabled = true
   file = "${params.outdir}/NGI-RNAseq_timeline.html"

--- a/nextflow.config
+++ b/nextflow.config
@@ -17,7 +17,16 @@ profiles {
 
   standard {
     includeConfig 'conf/base.config'
+  }
+  uppmax {
+    includeConfig 'conf/base.config'
     includeConfig 'conf/uppmax.config'
+    includeConfig 'conf/igenomes.config'
+  }
+  uppmax-modules {
+    includeConfig 'conf/base.config'
+    includeConfig 'conf/uppmax.config'
+    includeConfig 'conf/uppmax-modules.config'
     includeConfig 'conf/igenomes.config'
   }
   devel {
@@ -38,9 +47,6 @@ profiles {
     includeConfig 'conf/base.config'
     includeConfig 'conf/aws.config'
     includeConfig 'conf/igenomes.config'
-  }
-  base {
-    includeConfig 'conf/base.config'
   }
   testing {
     includeConfig 'conf/testing.config'

--- a/nextflow.config
+++ b/nextflow.config
@@ -23,13 +23,13 @@ profiles {
     includeConfig 'conf/uppmax.config'
     includeConfig 'conf/igenomes.config'
   }
-  uppmax-modules {
+  uppmax_modules {
     includeConfig 'conf/base.config'
     includeConfig 'conf/uppmax.config'
     includeConfig 'conf/uppmax-modules.config'
     includeConfig 'conf/igenomes.config'
   }
-  uppmax-devel {
+  uppmax_devel {
     includeConfig 'conf/base.config'
     includeConfig 'conf/uppmax.config'
     includeConfig 'conf/uppmax-devel.config'

--- a/tests/uppmax_test.sh
+++ b/tests/uppmax_test.sh
@@ -33,7 +33,7 @@ fi
 
 run_name="Test RNA Run: "$(date +%s)
 
-cmd="nextflow run $script_path -resume -name \"$run_name\" -profile uppmax-devel --gtf ${data_dir}/genes.gtf --bed12 ${data_dir}/genes.bed --star_index ${data_dir}/star/ --singleEnd --reads \"${data_dir}/*.fastq.gz\""
+cmd="nextflow run $script_path -resume -name \"$run_name\" -profile uppmax_devel --gtf ${data_dir}/genes.gtf --bed12 ${data_dir}/genes.bed --star_index ${data_dir}/star/ --singleEnd --reads \"${data_dir}/*.fastq.gz\""
 echo "Starting nextflow... Command:"
 echo $cmd
 echo "-----"

--- a/tests/uppmax_test.sh
+++ b/tests/uppmax_test.sh
@@ -33,9 +33,8 @@ fi
 
 run_name="Test RNA Run: "$(date +%s)
 
-cmd="nextflow run $script_path -resume -name \"$run_name\" -profile devel --gtf ${data_dir}/genes.gtf --bed12 ${data_dir}/genes.bed --star_index ${data_dir}/star/ --singleEnd --reads \"${data_dir}/*.fastq.gz\""
+cmd="nextflow run $script_path -resume -name \"$run_name\" -profile uppmax-devel --gtf ${data_dir}/genes.gtf --bed12 ${data_dir}/genes.bed --star_index ${data_dir}/star/ --singleEnd --reads \"${data_dir}/*.fastq.gz\""
 echo "Starting nextflow... Command:"
 echo $cmd
 echo "-----"
 eval $cmd
-

--- a/tests/uppmax_test_hisat.sh
+++ b/tests/uppmax_test_hisat.sh
@@ -33,7 +33,7 @@ fi
 
 run_name="Test RNA Run: "$(date +%s)
 
-cmd="nextflow run $script_path -resume -name \"$run_name\" -profile uppmax-devel --gtf ${data_dir}/genes.gtf --bed12 ${data_dir}/genes.bed --hisat2_index ${data_dir}/r64/ --aligner hisat2 --singleEnd --reads \"${data_dir}/*.fastq.gz\""
+cmd="nextflow run $script_path -resume -name \"$run_name\" -profile uppmax_devel --gtf ${data_dir}/genes.gtf --bed12 ${data_dir}/genes.bed --hisat2_index ${data_dir}/r64/ --aligner hisat2 --singleEnd --reads \"${data_dir}/*.fastq.gz\""
 echo "Starting nextflow... Command:"
 echo $cmd
 echo "-----"

--- a/tests/uppmax_test_hisat.sh
+++ b/tests/uppmax_test_hisat.sh
@@ -33,9 +33,8 @@ fi
 
 run_name="Test RNA Run: "$(date +%s)
 
-cmd="nextflow run $script_path -resume -name \"$run_name\" -profile devel --gtf ${data_dir}/genes.gtf --bed12 ${data_dir}/genes.bed --hisat2_index ${data_dir}/r64/ --aligner hisat2 --singleEnd --reads \"${data_dir}/*.fastq.gz\""
+cmd="nextflow run $script_path -resume -name \"$run_name\" -profile uppmax-devel --gtf ${data_dir}/genes.gtf --bed12 ${data_dir}/genes.bed --hisat2_index ${data_dir}/r64/ --aligner hisat2 --singleEnd --reads \"${data_dir}/*.fastq.gz\""
 echo "Starting nextflow... Command:"
 echo $cmd
 echo "-----"
 eval $cmd
-


### PR DESCRIPTION
Migrating the pipeline from environment modules to singularity.

Played with the profiles a bit here:

* **Important** - default config profile is now `base`, _not_ `uppmax`
* Use `-profile uppmax` to run on UPPMAX now - this config uses singularity
* `devel` profile renamed to `uppmax_devel` - also now uses singularity
* New `uppmax_modules` profile with old environment module setup

I added a check that throws two big ugly error messages if using the base config on a system that has `.uppmax.uu.se` in the `hostname` - hopefully this will help most users with the transition.

Note that the singularity tests won't work until this is merged, as the main docker image needs changes in this PR. To test (once the builds are complete), we can use `-with-singularity 'docker://ewels/ngi-rnaseq'`

Phil