### PR TITLE
Remove reverse stranded default for UPPMAX profile.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
 # NGI-RNAseq
 
 ## 1.4dev
-* Changed default config to base, **UPPMAX users now need to specify `-profile uppmax`**
+The version 1.4 release contains major improvements to the NGI-RNAseq pipeline, especially focussed on the portability of the pipeline. Hopefully these changes will make it significantly easier for people to use the pipeline in different compute environments.
+
+Many thanks to everyone who gave us feedback about the pipeline!
+
+* Changed default config to `base` instead of `uppmax`
+    * **UPPMAX users now need to specify `-profile uppmax`**
+* Removed default revse stranded config for UPPMAX profile
+    * **UPPMAX users now need to specify `--reverse_stranded` for the same behaviour**
 * Switched UPPMAX configuration to use Singularity instead of environment modules
+* Switched c3se Hebbe configuration to use Singularity & refactored config
 * Added a Troubleshooting section to the docs
-* Refactored config for `hebbe`
 * Fixed bug where BED12 generation failed when only GTF supplied.
 
 ## [1.3.1](https://github.com/SciLifeLab/NGI-RNAseq/releases/tag/1.3.1) - 2017-10-16

--- a/conf/uppmax.config
+++ b/conf/uppmax.config
@@ -21,7 +21,6 @@ process {
 
 params {
   saveReference = true
-  reverse_stranded = true
   rlocation = "/usr/local/lib/R/library"
   // Max resources requested by a normal node on milou. If you need more memory, run on a fat node using:
   //   --clusterOptions "-C mem512GB" --max_memory "512GB"

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -72,7 +72,19 @@ Three command line flags / config parameters set the library strandedness for a 
 * `--reverse_stranded`
 * `--unstranded`
 
-If not set, the pipeline will be run as unstranded. The UPPMAX configuration file sets `reverse_stranded` to true by default. Use `--unstranded` or `--forward_stranded` to overwrite this. Specifying `--pico` makes the pipeline run in `forward_stranded` mode.
+If not set, the pipeline will be run as unstranded. Specifying `--pico` makes the pipeline run in `forward_stranded` mode.
+
+You can set a default in a cutom Nextflow configuration file such as one saved in `~/.nextflow/config` (see the [nextflow docs](https://www.nextflow.io/docs/latest/config.html) for more). For example:
+
+```groovy
+params {
+    reverse_stranded = true
+}
+```
+
+> **NB:** Before v1.4 of the pipeline, the UPPMAX profile ran in reverse stranded mode by default. This was removed in the v1.4 release, so all profiles now run in unstranded mode by default.
+
+If you have a default strandedness set in your personal config file you can use `--unstranded` to overwrite it for a given run.
 
 These flags affect the commands used for several steps in the pipeline - namely HISAT2, featureCounts, RSeQC (`RPKM_saturation.py`) and StringTie:
 


### PR DESCRIPTION
Changed the default strandedness behaviour of the uppmax profile.

NOTE: Everyone who liked this setting - please add the following to your personal nextflow config file to maintain the same behaviour:

```groovy
params {
  reverse_stranded = true
}
```

The same will need to be added to the NGI production deployment for this release.

This default was not consistent within the pipeline and was catching people out. Better to default to unstranded (which usually works ok for all library types) and let people explicitly define their library type.