### PR TITLE
check_max - return memory and time objects

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -90,19 +90,23 @@ def check_max(obj, type) {
   if(type == 'memory'){
     try {
       if(obj.compareTo(params.max_memory as nextflow.util.MemoryUnit) == 1)
-        return params.max_memory
+        return params.max_memory as nextflow.util.MemoryUnit
+      else
+        return obj
     } catch (all) {
       println "   ### ERROR ###   Max memory '${params.max_memory}' is not valid! Using default value: $obj"
+      return obj
     }
-    return obj
   } else if(type == 'time'){
     try {
       if(obj.compareTo(params.max_time as nextflow.util.Duration) == 1)
-        return params.max_time
+        return params.max_time as nextflow.util.Duration
+      else
+        return obj
     } catch (all) {
       println "   ### ERROR ###   Max time '${params.max_time}' is not valid! Using default value: $obj"
+      return obj
     }
-    return obj
   } else if(type == 'cpus'){
     try {
       return Math.min( obj, params.max_cpus as int )


### PR DESCRIPTION
The `as nextflow.util.MemoryUnit` thing was working properly when comparing memories and times, but we were then returning the raw `params.max_memory` string again.

Small update to just return the `params.max_memory` as a Memory object