### PR TITLE
Save a help text file to the results directory if skipping intermediate files

### DIFF
--- a/assets/where_are_my_files.txt
+++ b/assets/where_are_my_files.txt
@@ -1,0 +1,39 @@
+=====================
+ Where are my files?
+=====================
+
+By default, the NGI-RNAseq pipeline does not save large intermediate files to the
+results directory. This is to try to conserve disk space.
+
+These files can be found in the pipeline `work` directory if needed.
+Alternatively, re-run the pipeline using `-resume` in addition to one of
+the below command-line options and they will be copied into the results directory:
+
+`--saveAlignedIntermediates`
+The final BAM files created after the Picard MarkDuplicates step are always saved
+and can be found in the `markDuplicates/` folder.
+Specify this flag to also copy out BAM files from STAR / HISAT2 alignment and sorting steps.
+
+`--saveTrimmed`
+Specify to save trimmed FastQ files to the results directory.
+
+`--saveReference`
+Save any downloaded or generated reference genome files to your results folder.
+These can then be used for future pipeline runs, reducing processing times.
+
+-----------------------------------
+ Setting defaults in a config file
+-----------------------------------
+If you would always like these files to be saved without having to specify this on
+the command line, you can save the following to your personal configuration file
+(eg. `~/.nextflow/config`):
+
+params.saveReference = true
+params.saveTrimmed = true
+params.saveAlignedIntermediates = true
+
+For more help, see the following documentation:
+
+https://github.com/SciLifeLab/NGI-RNAseq/blob/master/docs/usage.md
+https://www.nextflow.io/docs/latest/getstarted.html
+https://www.nextflow.io/docs/latest/config.html


### PR DESCRIPTION
Hopefully this will stop us from getting lots of people asking why they have no BAM files in their STAR results directory.