### PR TITLE
Defer execution of the docker tag version.

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -26,8 +26,6 @@ process {
     memory = { check_max( 80.GB * task.attempt, 'memory' ) }
     time = { check_max( 5.h * task.attempt, 'time' ) }
   }
-  $makeHisatSplicesites {
-  }
   $makeHISATindex {
     cpus = { check_max( 10 * task.attempt, 'cpus' ) }
     memory = { check_max( 80.GB * task.attempt, 'memory' ) }

--- a/nextflow.config
+++ b/nextflow.config
@@ -12,8 +12,7 @@ vim: syntax=groovy
 
 // Variable to specify the docker / singularity image tag to use
 // Picks up on use of -r 1.3 in nextflow command
-container_tag = workflow.revision ? workflow.revision : 'latest'
-wf_container = "scilifelab/ngi-rnaseq:${container_tag}"
+wf_container = { "scilifelab/ngi-chipseq:${workflow.revision ? workflow.revision : 'latest'}" }
 
 // Global default params, used in configs
 params {
@@ -123,4 +122,3 @@ def check_max(obj, type) {
     }
   }
 }
-

--- a/nextflow.config
+++ b/nextflow.config
@@ -12,7 +12,7 @@ vim: syntax=groovy
 
 // Variable to specify the docker / singularity image tag to use
 // Picks up on use of -r 1.3 in nextflow command
-wf_container = { "scilifelab/ngi-chipseq:${workflow.revision ? workflow.revision : 'latest'}" }
+wf_container = { "scilifelab/ngi-rnaseq:${workflow.revision ? workflow.revision : 'latest'}" }
 
 // Global default params, used in configs
 params {


### PR DESCRIPTION
This should fix the new failure that appears in Nextflow v0.27 that was due to a previously unseen bug. See https://github.com/SciLifeLab/NGI-ChIPseq/issues/59