### PR TITLE
Avoid filename truncation in dupradar.r (+remove detectcores)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Many thanks to everyone who gave us feedback about the pipeline!
 * Reorganised and rewrote much of the documentation
 * Added a Troubleshooting section to the docs
 * Fixed bug where BED12 generation failed when only GTF supplied.
+* Changed dupradar script to use number of threads defined by nextflow process
+* Fixed call to dupradar script that prevented paired-ends interpretation of data
 
 ## [1.3.1](https://github.com/SciLifeLab/NGI-RNAseq/releases/tag/1.3.1) - 2017-10-16
 Hotfix to update version number in pipeline script.

--- a/bin/dupRadar.r
+++ b/bin/dupRadar.r
@@ -8,7 +8,14 @@ if (length(args) < 3) {
 input_bam <- args[1]
 annotation_gtf <- args[2]
 paired_end <- if(args[3]=='paired') TRUE else FALSE
-input_bam_basename <- strsplit(input_bam, "\\.")[[1]][1]
+
+bamRegex <- "(.*)\\.bam"
+
+if(!(grepl(bamRegex, input_bam) && file.exists(input_bam) &&  (!file.info(input_bam)$isdir))) stop("First argument '<input.bam>' must be an existing file (not a directory) with '.bam' extension...")
+if(!(file.exists(annotation_gtf) &&  (!file.info(annotation_gtf)$isdir))) stop("Second argument '<annotation.gtf>' must be an existing file (and not a directory)...")
+
+# Remove bam file extension to generate basename
+input_bam_basename <- gsub(bamRegex, "\\1", input_bam)
 
 # Load / install packages
 if (length(args) > 3) { .libPaths( c( args[4], .libPaths() ) ) }
@@ -29,7 +36,7 @@ dm <- analyzeDuprates(input_bam, annotation_gtf, stranded, paired_end, threads)
 write.table(dm, file=paste(input_bam_basename, "_dupMatrix.txt", sep=""), quote=F, row.name=F, sep="\t")
 
 # 2D density scatter plot
-pdf(paste0(input_bam, "_duprateExpDens.pdf"))
+pdf(paste0(input_bam_basename, "_duprateExpDens.pdf"))
 duprateExpDensPlot(DupMat=dm)
 title("Density scatter plot")
 mtext(input_bam_basename, side=3)

--- a/bin/dupRadar.r
+++ b/bin/dupRadar.r
@@ -9,7 +9,7 @@ input_bam <- args[1]
 annotation_gtf <- args[2]
 paired_end <- if(args[3]=='paired') TRUE else FALSE
 
-bamRegex <- "(.+)\\.bam"
+bamRegex <- "(.+)\\.bam$"
 
 if(!(grepl(bamRegex, input_bam) && file.exists(input_bam) &&  (!file.info(input_bam)$isdir))) stop("First argument '<input.bam>' must be an existing file (not a directory) with '.bam' extension...")
 if(!(file.exists(annotation_gtf) &&  (!file.info(annotation_gtf)$isdir))) stop("Second argument '<annotation.gtf>' must be an existing file (and not a directory)...")

--- a/bin/dupRadar.r
+++ b/bin/dupRadar.r
@@ -2,23 +2,34 @@
 
 # Command line argument processing
 args = commandArgs(trailingOnly=TRUE)
-if (length(args) < 3) {
-  stop("Usage: dupRadar.r <input.bam> <annotation.gtf> <paired/single> <R-package-location (optional)>", call.=FALSE)
+if (length(args) < 4) {
+  stop("Usage: dupRadar.r <input.bam> <annotation.gtf> <paired/single> <nbThreads> <R-package-location (optional)>", call.=FALSE)
 }
 input_bam <- args[1]
 annotation_gtf <- args[2]
 paired_end <- if(args[3]=='paired') TRUE else FALSE
+threads <- as.numeric(args[4])
 
 bamRegex <- "(.+)\\.bam$"
 
 if(!(grepl(bamRegex, input_bam) && file.exists(input_bam) &&  (!file.info(input_bam)$isdir))) stop("First argument '<input.bam>' must be an existing file (not a directory) with '.bam' extension...")
 if(!(file.exists(annotation_gtf) &&  (!file.info(annotation_gtf)$isdir))) stop("Second argument '<annotation.gtf>' must be an existing file (and not a directory)...")
+if(is.na(threads) || (threads<=0)) stop("Fourth argument <nbThreads> must be a strictly positive numeric value...")
 
 # Remove bam file extension to generate basename
 input_bam_basename <- gsub(bamRegex, "\\1", input_bam)
 
+# Debug messages (stderr)
+message("Input bam      (Arg 1): ", input_bam)
+message("Input gtf      (Arg 2): ", annotation_gtf)
+message("paired/single  (Arg 3): ", ifelse(paired_end, 'paired', 'single'))
+message("Nb threads     (Arg 4): ", threads)
+message("R package loc. (Arg 5): ", ifelse(length(args) > 4, args[5], "Not specified"))
+message("Output basename       : ", input_bam_basename)
+
+
 # Load / install packages
-if (length(args) > 3) { .libPaths( c( args[4], .libPaths() ) ) }
+if (length(args) > 4) { .libPaths( c( args[5], .libPaths() ) ) }
 if (!require("dupRadar")){
   source("http://bioconductor.org/biocLite.R")
   biocLite("dupRadar", suppressUpdates=TRUE)
@@ -31,7 +42,6 @@ if (!require("parallel")) {
 
 # Duplicate stats
 stranded <- 2
-threads <- detectCores()
 dm <- analyzeDuprates(input_bam, annotation_gtf, stranded, paired_end, threads)
 write.table(dm, file=paste(input_bam_basename, "_dupMatrix.txt", sep=""), quote=F, row.name=F, sep="\t")
 

--- a/bin/dupRadar.r
+++ b/bin/dupRadar.r
@@ -9,7 +9,7 @@ input_bam <- args[1]
 annotation_gtf <- args[2]
 paired_end <- if(args[3]=='paired') TRUE else FALSE
 
-bamRegex <- "(.*)\\.bam"
+bamRegex <- "(.+)\\.bam"
 
 if(!(grepl(bamRegex, input_bam) && file.exists(input_bam) &&  (!file.info(input_bam)$isdir))) stop("First argument '<input.bam>' must be an existing file (not a directory) with '.bam' extension...")
 if(!(file.exists(annotation_gtf) &&  (!file.info(annotation_gtf)$isdir))) stop("Second argument '<annotation.gtf>' must be an existing file (and not a directory)...")

--- a/main.nf
+++ b/main.nf
@@ -891,7 +891,7 @@ process dupradar {
     def paired = params.singleEnd ? 'FALSE' :  'TRUE'
     def rlocation = params.rlocation ?: ''
     """
-    dupRadar.r $bam_md $gtf $paired $rlocation
+    dupRadar.r $bam_md $gtf $paired ${task.cpus} $rlocation
     """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -888,7 +888,7 @@ process dupradar {
     file "*.{pdf,txt}" into dupradar_results
 
     script: // This script is bundled with the pipeline, in NGI-RNAseq/bin/
-    def paired = params.singleEnd ? 'FALSE' :  'TRUE'
+    def paired = params.singleEnd ? 'single' :  'paired'
     def rlocation = params.rlocation ?: ''
     """
     dupRadar.r $bam_md $gtf $paired ${task.cpus} $rlocation


### PR DESCRIPTION
* Changed the method to generate basename from input_bam file name.
    * Previous method prevented the use of dots in bam filename (truncation of file name at first dot).
* Added `file.exists` checks for bam and gtf files with error message (+bam file must have `.bam` extension).
* Used basename instead of full bam filename for `_duprateExpDens.pdf` output (to be consistent with other outputs)