### PR TITLE
Don't use uppmax.config for uppmax-modules.config

### DIFF
--- a/conf/uppmax-modules.config
+++ b/conf/uppmax-modules.config
@@ -6,11 +6,12 @@ vim: syntax=groovy
  * -------------------------------------------------
  */
 
-singularity {
-  enabled = false
-}
-
 process {
+
+  // Global process config
+  executor = 'slurm'
+  clusterOptions = { "-A $params.project ${params.clusterOptions ?: ''}" }
+
   // Load bioinfo-tools module before we start
   beforeScript = 'module load bioinfo-tools'
 
@@ -39,5 +40,15 @@ process {
 }
 
 params {
+  saveReference = true
+  rlocation = "/usr/local/lib/R/library"
+  // Max resources requested by a normal node on milou. If you need more memory, run on a fat node using:
+  //   --clusterOptions "-C mem512GB" --max_memory "512GB"
+  max_memory = 128.GB
+  max_cpus = 16
+  max_time = 240.h
+  // illumina iGenomes reference file paths on UPPMAX
+  igenomes_base = '/sw/data/uppnex/igenomes/'
+  // R installation location
   rlocation = "$HOME/R/nxtflow_libs/"
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -34,7 +34,6 @@ profiles {
   }
   uppmax_modules {
     includeConfig 'conf/base.config'
-    includeConfig 'conf/uppmax.config'
     includeConfig 'conf/uppmax-modules.config'
     includeConfig 'conf/igenomes.config'
   }


### PR DESCRIPTION
Short term workaround until nextflow-io/nextflow#628 is released.

Should fix the problem where the `uppmax-modules` config tries to download the singularity container even when it's not needed.