### PR TITLE
Add option to specify strand direction for dupradar script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Many thanks to everyone who gave us feedback about the pipeline!
 * Added a Troubleshooting section to the docs
 * Fixed bug where BED12 generation failed when only GTF supplied.
 * Changed dupradar script to use number of threads defined by nextflow process
-* Fixed call to dupradar script that prevented paired-ends interpretation of data
+* Fixed call to dupradar script that prevented interpretation of paired-ends reads and strand direction
 
 ## [1.3.1](https://github.com/SciLifeLab/NGI-RNAseq/releases/tag/1.3.1) - 2017-10-16
 Hotfix to update version number in pipeline script.

--- a/main.nf
+++ b/main.nf
@@ -888,10 +888,16 @@ process dupradar {
     file "*.{pdf,txt}" into dupradar_results
 
     script: // This script is bundled with the pipeline, in NGI-RNAseq/bin/
+    def dupradar_direction = 0
+    if (forward_stranded && !unstranded) {
+        dupradar_direction = 1
+    } else if (reverse_stranded && !unstranded){
+        dupradar_direction = 2
+    }    
     def paired = params.singleEnd ? 'single' :  'paired'
     def rlocation = params.rlocation ?: ''
     """
-    dupRadar.r $bam_md $gtf $paired ${task.cpus} $rlocation
+    dupRadar.r $bamFile $gtfFile $dupradar_direction $paired ${task.cpus} $rlocation
     """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -897,7 +897,7 @@ process dupradar {
     def paired = params.singleEnd ? 'single' :  'paired'
     def rlocation = params.rlocation ?: ''
     """
-    dupRadar.r $bamFile $gtfFile $dupradar_direction $paired ${task.cpus} $rlocation
+    dupRadar.r $bam_md $gtf $dupradar_direction $paired ${task.cpus} $rlocation
     """
 }
 


### PR DESCRIPTION
Add command line option to `dupradar.r` script.

Check values validity and pass to `analyzeDuprates` function.

Update other command line arguments (indexes).

Translation and use of nextflow pipeline variables (`forward_stranded`, `reverse_stranded`, and `unstranded`) for `dupradar.r` script.