### PR TITLE
Removed non-default option from star

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -397,7 +397,6 @@ if(params.aligner == 'star' && !params.star_index && fasta){
             --runMode genomeGenerate \\
             --runThreadN ${task.cpus} \\
             --sjdbGTFfile $gtf \\
-            --sjdbOverhang 149 \\
             --genomeDir star/ \\
             --genomeFastaFiles $fasta
         """


### PR DESCRIPTION
See https://github.com/SciLifeLab/NGI-RNAseq/issues/211#issue-306233190 for the discussion. 
The default value of STAR `genomeGenerate` is most likely absolutely fine. Fixes  #211 